### PR TITLE
Design: 메인 페이지 추합 작업

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,4 @@
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+// import { BrowserRouter, Routes, Route } from 'react-router-dom';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
 import Main from './pages/main/Main';
 

--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -1,4 +1,4 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const Button = tw.button`
   text-sm

--- a/client/src/commons/atoms/buttons/PurpleBtn.tsx
+++ b/client/src/commons/atoms/buttons/PurpleBtn.tsx
@@ -1,0 +1,21 @@
+import tw from 'twin.macro';
+import { styled } from 'styled-components';
+import { Button } from './Button.styled';
+
+const Purpletype = styled(Button)`
+  ${tw`bg-POINT_COLOR
+  w-fit
+  whitespace-nowrap`}
+
+  &:hover {
+    ${tw`bg-HOVER_COLOR`}
+  }
+`;
+
+interface PurpleBtnProps {
+  children?: React.ReactNode;
+}
+
+export default function PurpleBtn( {children}: PurpleBtnProps ) {
+  return <Purpletype>{children}</Purpletype>;
+}

--- a/client/src/commons/atoms/buttons/category/CategoryButton.tsx
+++ b/client/src/commons/atoms/buttons/category/CategoryButton.tsx
@@ -8,11 +8,16 @@ export interface CategoryBtnProps {
 
 const Category = styled.button`
     width: 180px;
-    ${tw`h-12 p-3 rounded-full border-0`}
+    ${tw`h-12 p-3 rounded-full border-0 whitespace-nowrap`}
     background-color: rgba(245, 245, 245, 0.51);
     box-shadow: 0 10px 24px hsla(0,0%,0%,0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
 
     &:active {
+        color: white;
+        box-shadow:inset 3px 3px 5px rgba(0, 0, 0, .1);
+    }
+    
+    &:focus {
         color: white;
         box-shadow:inset 3px 3px 5px rgba(0, 0, 0, .1);
     }
@@ -23,4 +28,4 @@ export default function CategoryButton({category}:CategoryBtnProps){
     return (
         <Category>{category}</Category>
     );
-};
+}

--- a/client/src/commons/atoms/buttons/login/LoginBtn.styled.tsx
+++ b/client/src/commons/atoms/buttons/login/LoginBtn.styled.tsx
@@ -1,7 +1,0 @@
-import tw from 'tailwind-styled-components';
-import { Button } from '../Button.styled';
-
-export const LoginButton = tw(Button)`
-  bg-[#8580E1]
-  hover:bg-[#6A66B4]
-`;

--- a/client/src/commons/atoms/buttons/login/LoginBtn.tsx
+++ b/client/src/commons/atoms/buttons/login/LoginBtn.tsx
@@ -1,5 +1,6 @@
-import { LoginButton } from './LoginBtn.styled';
+import PurpleBtn from "../PurpleBtn";
+
 
 export default function LoginBtn() {
-  return <LoginButton>Login</LoginButton>;
+  return <PurpleBtn>로그인</PurpleBtn>;
 }

--- a/client/src/commons/atoms/footer/Footer.styled.tsx
+++ b/client/src/commons/atoms/footer/Footer.styled.tsx
@@ -7,7 +7,6 @@ export const FooterContainer = tw.div`
   justify-center 
   items-center 
   h-14
-  botton-0
 `;
 
 export const FooterText = tw.div`

--- a/client/src/commons/atoms/footer/Footer.styled.tsx
+++ b/client/src/commons/atoms/footer/Footer.styled.tsx
@@ -1,4 +1,4 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const FooterContainer = tw.div`
   bg-BASIC_GRAY 
@@ -6,7 +6,7 @@ export const FooterContainer = tw.div`
   flex 
   justify-center 
   items-center 
-  h-10
+  h-14
   botton-0
 `;
 

--- a/client/src/commons/atoms/header/Header.styled.tsx
+++ b/client/src/commons/atoms/header/Header.styled.tsx
@@ -1,4 +1,4 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const HeaderContainer = tw.div`
   flex
@@ -17,14 +17,16 @@ export const LogoImg = tw.img`
   w-12
   h-12
 `;
+
 export const ItemContainer = tw.div`
   flex
   flex-1
   justify-end
-  items-center
 `;
 
 export const CLink = tw.a`
-  mr-4
+  mx-4
   hover:underline
+  cursor-pointer
+  whitespace-nowrap
 `;

--- a/client/src/commons/atoms/header/Header.tsx
+++ b/client/src/commons/atoms/header/Header.tsx
@@ -13,7 +13,7 @@ export default function Header() {
       <Search />
       <ItemContainer>
         <CLink>community</CLink>
-        {isLogin ? <UserImg /> : <LoginBtn />}
+        {isLogin ? <UserImg /> : <LoginBtn/> }
       </ItemContainer>
     </HeaderContainer>
   );

--- a/client/src/commons/atoms/logo/Logo.styled.tsx
+++ b/client/src/commons/atoms/logo/Logo.styled.tsx
@@ -1,4 +1,4 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const LogoContainer = tw.div`
   flex

--- a/client/src/commons/atoms/navbar/CategoryNavBar.tsx
+++ b/client/src/commons/atoms/navbar/CategoryNavBar.tsx
@@ -1,4 +1,4 @@
-import CategoryButton from '@/commons/atoms/buttons/CategoryButton';
+import CategoryButton from '@/commons/atoms/buttons/category/CategoryButton';
 import { FlexContainer } from '@/commons/styles/Containers.styled';
 
 

--- a/client/src/commons/atoms/user/UserImg.styled.tsx
+++ b/client/src/commons/atoms/user/UserImg.styled.tsx
@@ -11,7 +11,7 @@ export const ImgContainer = tw.div`
   border-transparent
   transition-all
   hover:border-2
-  hover:border-white-500
+  hover:border-white
 `;
 
 export const UserImage = tw.img`

--- a/client/src/components/bookmark/Bookmark.styled.tsx
+++ b/client/src/components/bookmark/Bookmark.styled.tsx
@@ -1,5 +1,5 @@
 import { FaBookmark } from 'react-icons/fa';
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const BookmarkContainer = tw.div`
   inline-block

--- a/client/src/components/bookmark/Bookmark.styled.tsx
+++ b/client/src/components/bookmark/Bookmark.styled.tsx
@@ -16,5 +16,7 @@ export const BookmarkButton = tw(FaBookmark)`
 `;
 
 export const StyledBookmarkButton = tw(BookmarkButton)`
-  ${(props) => (props.clicked ? 'text-[#ffeb54]' : '')}
+ 
 `;
+ // ${(props) => (props.clicked ? 'text-[#ffeb54]' : '')}
+

--- a/client/src/components/dropdown/Dropdown.styled.tsx
+++ b/client/src/components/dropdown/Dropdown.styled.tsx
@@ -1,0 +1,22 @@
+import tw from 'twin.macro';
+import { styled } from 'styled-components';
+
+export const ModalLink = styled.li`
+    ${ tw`
+        py-1
+        text-[8px]
+        font-semibold
+        flex
+        flex-row
+        items-center
+        justify-center
+        cursor-pointer
+    `}
+
+    &:hover{
+        ${tw`
+            bg-HOVER_COLOR
+            text-BASIC_WHITE
+        `}
+    }
+`;

--- a/client/src/components/dropdown/Dropdown.tsx
+++ b/client/src/components/dropdown/Dropdown.tsx
@@ -1,0 +1,16 @@
+import {VscBell} from 'react-icons/vsc';
+import { ModalLink } from './Dropdown.styled';
+
+export default function Dropwdown () {
+    return(
+        <div className="shadow-md w-24 rounded-lg overflow-hidden">
+            <ul className="divide-y divide-zinc-200">
+                <ModalLink><div className="mr-1"><VscBell size="10"/></div>Alarm</ModalLink>
+                <ModalLink>My Page</ModalLink>
+                <ModalLink>New Portfolio</ModalLink>
+                <ModalLink>Log Out</ModalLink>
+            </ul>
+
+        </div>
+    )
+}

--- a/client/src/components/search/Search.styled.tsx
+++ b/client/src/components/search/Search.styled.tsx
@@ -1,26 +1,32 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
+import { styled } from 'styled-components';
 import { BsSearchHeart } from 'react-icons/bs';
 
 export const SearchContainer = tw.div`
   relative
   flex
-  flex-3
+  flex-1
   flex-grow
   items-center
 `;
 
 export const SearchIcon = tw(BsSearchHeart)`
   absolute
-  ml-5
+  ml-5 
   top-1/2
   transform -translate-y-1/2
 `;
 
-export const SearchBox = tw.input`
-  pl-12
-  h-9
-  w-full
-  rounded-full	
-  bg-[#ececec]
-  focus:outline-none
+export const SearchBox = styled.input`
+  ${tw`
+    pl-12
+    h-9
+    w-full
+    rounded-full	
+    bg-[#ececec]
+  `}
+  
+  &:focus {
+    ${tw`outline-none`}
+  }
 `;

--- a/client/src/components/webItem/WebItem.styled.tsx
+++ b/client/src/components/webItem/WebItem.styled.tsx
@@ -7,8 +7,7 @@ export const WebItemContainer = styled.div`
   h-72
   w-96
   relative
-  shadow-md
-  position-relative`}
+  shadow-md`}
   
   &:hover{
     ${tw`bg-neutral-500/60`}

--- a/client/src/components/webItem/WebItem.styled.tsx
+++ b/client/src/components/webItem/WebItem.styled.tsx
@@ -1,18 +1,28 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
+import { styled } from 'styled-components';
 
-export const WebItemContainer = tw.div`
-  my-6
-  h-96
-  w-85
+export const WebItemContainer = styled.div`
+  ${tw`my-6
+  mx-6
+  h-72
+  w-96
   relative
   shadow-md
-  hover:bg-neutral-500/60
-  position-relative
+  position-relative`}
+  
+  &:hover{
+    ${tw`bg-neutral-500/60`}
+  }
+
 `;
 
-export const WebItemImg = tw.img`
-  w-full
-  h-full
-  object-cover
-  hover:opacity-80
+export const WebItemImg = styled.img`
+  ${tw`
+    w-full
+    h-full
+    object-cover
+  `}
+  &:hover{
+    ${tw`opacity-80`}
+  }
 `;

--- a/client/src/pages/main/Main.styled.tsx
+++ b/client/src/pages/main/Main.styled.tsx
@@ -4,9 +4,7 @@ export const WebItemsContainer = tw.div`
   flex 
   flex-wrap 
   justify-center
-  space-x-6
   mt-10
   md:(flex-row)
   sm:(flex-col)
-  space-x-32
 `;

--- a/client/src/pages/main/Main.styled.tsx
+++ b/client/src/pages/main/Main.styled.tsx
@@ -1,4 +1,4 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
 
 export const WebItemsContainer = tw.div`
   flex 

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -10,13 +10,20 @@ export default function Main() {
       <Header />
       <CategoryNavBar />
       <WebItemsContainer>
+        {Array.from({length:4}).map((_, index) => {
+          return (
+            <WebItem key={index}/>
+          )
+        })}
+      </WebItemsContainer>
+      {/* <WebItemsContainer>
         <WebItem />
         <WebItem />
       </WebItemsContainer>
       <WebItemsContainer>
         <WebItem />
         <WebItem />
-      </WebItemsContainer>
+      </WebItemsContainer> */}
       <Footer />
     </>
   );

--- a/client/src/stories/buttons/Buttons.stories.tsx
+++ b/client/src/stories/buttons/Buttons.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CategoryButton, {CategoryBtnProps} from '../../commons/atoms/buttons/CategoryButton';
+import CategoryButton, {CategoryBtnProps} from '../../commons/atoms/buttons/category/CategoryButton';
 import { Meta } from "@storybook/react"
 
 export default {

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -4,12 +4,11 @@
     "useDefineForClassFields": true,
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "module": "ESNext",
-    "skipLibCheck": true,
     "types": ["node"],
     "allowJs": false,
-    "esModuleInterop": false,
+    "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "paths": {
       "@/*": ["./src/*"]


### PR DESCRIPTION
# 개요 
메인 페이지 추합 작업입니다. 

# 작업 사항
1. 글자가 들어가는 부분은 whitespace-nowrap 속성을 추가하여 창 사이즈가 줄어들더라도 다음 줄로 넘어가지 않도록 수정하였습니다. 
2. 북마크 부분은 props 설정 시 타입 미 설정으로 우선 주석 처리 하였습니다. src/Bookmarked.styled.tsx
3. 카테고리 아이템 메인 페이지 정렬은 Array.from(length: 4) 형식으로 4개 우선 불러오는 작업 진행했습니다. 
4. 카테고리 Nav 에 focus 요소 추가하였습니다. 
5. Button 은 Button.styled.tsx 사용하여 children 부분 안에 글자 작성해서 사용 할 수 있게 변경 하였습니다. 

# 스크린 샷 
![스크린샷 2023-07-04 오전 11 21 06](https://github.com/codestates-seb/seb44_main_013/assets/110151638/0678341a-1f38-458d-a77d-a35e0b5a12f1)
