### PR TITLE
Design: 게시판 목록의 writing Button 생성

### DIFF
--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -1,4 +1,5 @@
 import tw from 'twin.macro';
+import { styled } from 'styled-components';
 
 export const Button = tw.button`
   text-sm
@@ -8,4 +9,21 @@ export const Button = tw.button`
   py-1
   transition duration-300 ease-in-out
   max-md:text-xs
+`;
+
+export const Purpletype = styled(Button)`
+  ${tw`bg-POINT_COLOR
+  w-fit
+  whitespace-nowrap`}
+
+  &:hover {
+    ${tw`bg-HOVER_COLOR`}
+  }
+`;
+
+export const Writingtype = styled(Purpletype)`
+  ${tw`
+    px-10
+    py-2
+  `}
 `;

--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -21,6 +21,7 @@ export const Purpletype = styled(Button)`
   }
 `;
 
+//writingBtn 커스터마이징 타입
 export const Writingtype = styled(Purpletype)`
   ${tw`
     px-10

--- a/client/src/commons/atoms/buttons/PurpleBtn.tsx
+++ b/client/src/commons/atoms/buttons/PurpleBtn.tsx
@@ -1,21 +1,11 @@
-import tw from 'twin.macro';
-import { styled } from 'styled-components';
-import { Button } from './Button.styled';
-
-const Purpletype = styled(Button)`
-  ${tw`bg-POINT_COLOR
-  w-fit
-  whitespace-nowrap`}
-
-  &:hover {
-    ${tw`bg-HOVER_COLOR`}
-  }
-`;
+import { Purpletype } from "./Button.styled";
 
 interface PurpleBtnProps {
   children?: React.ReactNode;
 }
 
+//기본 퍼플 타입 버튼 
+//children 안에 원하는 글자를 작성하면 됩니다. 
 export default function PurpleBtn( {children}: PurpleBtnProps ) {
   return <Purpletype>{children}</Purpletype>;
 }

--- a/client/src/commons/atoms/buttons/writing/writingBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/writingBtn.tsx
@@ -1,0 +1,5 @@
+import { Writingtype } from "../Button.styled"
+
+export default function WritingBtn(){
+    return <Writingtype>Writing</Writingtype>
+}


### PR DESCRIPTION
# 개요 
게시판 목록의 Writing Button 관련 PR 입니다. 

# 작업 사항 
1. 버튼의 활용을 위해 한번 더 폴더 구조를 수정하였습니다. 
```bash
└─buttons
      └─caategory
      └─login
      └─writing
      └─Button.styled.tsx
      └─PurpleBtn.tsx
```
* 각 category/login/writing 폴더 안에는 커스터마이징 버튼이 있습니다. 
     - 추합할 때 해당 컴포넌트 이름만 불러오면 됩니다. 
     - 예시 : ```<WritingBtn/>```
* Button.styled.tsx 파일 안에는 다양한 커스터마이징이 적용된 버튼들이 있습니다. 
* PurpleBtn.tsx 파일은 각 기본 보라색 버튼의 최종 모체입니다. 


#스크린샷
<img width="156" alt="스크린샷 2023-07-04 오후 1 37 48" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/74838d06-f38e-4ff8-b8c8-23b65b8a8099">

