### PR TITLE
Design: 게시물 상세 페이지의 삭제/수정 버튼  + 및 댓글 저장 버튼 생성

### DIFF
--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -28,3 +28,14 @@ export const Writingtype = styled(Purpletype)`
     py-2
   `}
 `;
+
+//EditBtn & DeleteBtn 커스터마이징 타입
+export const Edittype = styled(Purpletype)`
+  ${tw`
+    bg-zinc-300
+    w-20
+    py-1
+    text-base
+    rounded-lg
+  `}
+`;

--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -1,4 +1,5 @@
 import tw from 'twin.macro';
+import { styled } from 'styled-components';
 
 export const Button = tw.button`
   text-sm
@@ -8,4 +9,21 @@ export const Button = tw.button`
   py-1
   transition duration-300 ease-in-out
   max-md:text-xs
+`;
+
+export const Purpletype = styled(Button)`
+  ${tw`bg-POINT_COLOR
+  w-fit
+  whitespace-nowrap`}
+
+  &:hover {
+    ${tw`bg-HOVER_COLOR`}
+  }
+`;
+
+export const Writingtype = styled(Purpletype)`
+  ${tw`
+    px-10
+    py-2
+  `}
 `;

--- a/client/src/commons/atoms/buttons/Button.styled.tsx
+++ b/client/src/commons/atoms/buttons/Button.styled.tsx
@@ -21,6 +21,7 @@ export const Purpletype = styled(Button)`
   }
 `;
 
+//writingBtn 커스터마이징 타입
 export const Writingtype = styled(Purpletype)`
   ${tw`
     px-10

--- a/client/src/commons/atoms/buttons/PurpleBtn.tsx
+++ b/client/src/commons/atoms/buttons/PurpleBtn.tsx
@@ -1,21 +1,11 @@
-import tw from 'twin.macro';
-import { styled } from 'styled-components';
-import { Button } from './Button.styled';
-
-const Purpletype = styled(Button)`
-  ${tw`bg-POINT_COLOR
-  w-fit
-  whitespace-nowrap`}
-
-  &:hover {
-    ${tw`bg-HOVER_COLOR`}
-  }
-`;
+import { Purpletype } from "./Button.styled";
 
 interface PurpleBtnProps {
   children?: React.ReactNode;
 }
 
+//기본 퍼플 타입 버튼 
+//children 안에 원하는 글자를 작성하면 됩니다. 
 export default function PurpleBtn( {children}: PurpleBtnProps ) {
   return <Purpletype>{children}</Purpletype>;
 }

--- a/client/src/commons/atoms/buttons/writing/DeleteBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/DeleteBtn.tsx
@@ -1,0 +1,5 @@
+import { Edittype } from "../Button.styled"
+
+export default function DeleteBtn(){
+    return <Edittype>Delete</Edittype>
+}

--- a/client/src/commons/atoms/buttons/writing/EditBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/EditBtn.tsx
@@ -1,0 +1,5 @@
+import { Edittype } from "../Button.styled"
+
+export default function EditBtn(){
+    return <Edittype>Edit</Edittype>
+}

--- a/client/src/commons/atoms/buttons/writing/SaveBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/SaveBtn.tsx
@@ -1,0 +1,5 @@
+import { Edittype } from "../Button.styled"
+
+export default function SaveBtn(){
+    return <Edittype>Save</Edittype>
+}

--- a/client/src/commons/atoms/buttons/writing/writingBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/writingBtn.tsx
@@ -1,0 +1,5 @@
+import { Writingtype } from "../Button.styled"
+
+export default function WritingBtn(){
+    return <Writingtype>Writing</Writingtype>
+}


### PR DESCRIPTION
# 개요 
게시물 상세 페이지에서 하단의 삭제/수정 버튼 생성

# 작업 사항 
1. 게시물 삭제 / 수정 버튼
- bg-zinc-300 # d4d4d8 색깔로 작업했습니다. 
- Hover 시에만 HOVER_COLOR 적용 됩니다. 

2. 댓글 저장 버튼 
- 위 삭제/수정 버튼과 동일하게 동작합니다. 

# 스크린 샷
#### - hover 시 
<img width="81" alt="스크린샷 2023-07-04 오후 2 14 27" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/3e14efd0-12d7-40f7-b02f-6d72d9a1f7fa">

<br/>

#### - 기본 상태
<img width="215" alt="스크린샷 2023-07-04 오후 2 14 21" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/4ef21b03-7b3c-4d27-82f8-cccac821c84d">


#### - 저장 버튼
<img width="110" alt="스크린샷 2023-07-04 오후 2 22 10" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/3de71e02-7e70-4816-a00d-6386a6635de0">


