### PR TITLE
[FRONT] 게시물 상세보기 페이지 댓글 컴포넌트 UI

### DIFF
--- a/client/src/commons/atoms/Card.tsx
+++ b/client/src/commons/atoms/Card.tsx
@@ -1,0 +1,25 @@
+/* 2023-07-05 각종 컴포넌트를 담는 Card 컴포넌트 - 김다함 */
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+import { ComponentPropsWithoutRef, ReactNode } from 'react';
+
+interface CardProps extends ComponentPropsWithoutRef<'div'> {
+    children: ReactNode;
+}
+
+const CardContainer = styled.div`
+    ${tw`flex flex-col w-full h-full p-5 box-border rounded-lg`}
+
+    background-color: white;
+    box-sizing: inherit;
+
+    box-shadow: 0 10px 24px hsla(0,0%,0%,0.05), 0 20px 48px hsla(0, 0%, 0%, 0.05), 0 1px 4px hsla(0, 0%, 0%, 0.1);
+`;
+
+export default function Card({ children }: CardProps) {
+    return (
+        <CardContainer>
+            {children}
+        </CardContainer>
+    )
+}

--- a/client/src/commons/atoms/Image.tsx
+++ b/client/src/commons/atoms/Image.tsx
@@ -1,4 +1,5 @@
-import {styled, css} from 'styled-components';
+/* 2023-07-04 주소, 모양, 사이즈를 입력 받는 이미지 아토믹 컴포넌트 - 김다함*/
+import { styled, css } from 'styled-components';
 import tw from 'twin.macro';
 
 interface ImageProps {
@@ -7,26 +8,26 @@ interface ImageProps {
     size: number | string;
 }
 
-const ImageContainer = styled.div<{shape?:string, size:number|string}>`
-    ${(props)=> props.shape === 'circle' &&
+const ImageContainer = styled.div<{ shape?: string, size: number | string }>`
+    ${(props) => props.shape === 'circle' &&
         css`
             width: ${typeof props.size === 'string' ? props.size : `${props.size}px`};
             height: ${typeof props.size === 'string' ? props.size : `${props.size}px`};
         `
-        // &&
-        // tw`overflow-hidden`
+    // &&
+    // tw`overflow-hidden`
     }
 `
 
-const FeatherImage = styled.img<{shape?:string, size:number|string}>`
-    ${(props)=> props.shape === 'circle' && tw`rounded-full min-w-full min-h-full`}
-    height: ${(props)=> typeof props.size === 'string' ? props.size : `${props.size}px`};
+const FeatherImage = styled.img<{ shape?: string, size: number | string }>`
+    ${(props) => props.shape === 'circle' && tw`rounded-full min-w-full min-h-full`}
+    height: ${(props) => typeof props.size === 'string' ? props.size : `${props.size}px`};
 `;
 
-export const Image = ({url, shape, size}:ImageProps)=>{
+export const Image = ({ url, shape, size }: ImageProps) => {
     return (
         <ImageContainer shape={shape} size={size}>
-            <FeatherImage src={url} shape={shape} size={size}/>
+            <FeatherImage src={url} shape={shape} size={size} />
         </ImageContainer>
     )
 }

--- a/client/src/commons/atoms/Label.tsx
+++ b/client/src/commons/atoms/Label.tsx
@@ -1,18 +1,19 @@
+/* 2023-07-04 다양한 크기의 볼드체 컴포넌트(UserProfile에 사용됨) - 김다함*/
 import { styled } from 'styled-components';
 
 interface LabelProps {
-    text:string;
-    size:number;
+    text: string;
+    size: number;
 }
 
-const Text = styled.label<{size:number}>`
-    font-size: ${(props)=>props.size}px;
+const Text = styled.label<{ size: number }>`
+    font-size: ${(props) => props.size}px;
     font-weight: 600;
     color: #232629;
 `;
 
-const Label = ({size, text}:LabelProps) => {
-    return(
+const Label = ({ size, text }: LabelProps) => {
+    return (
         <Text size={size}>{text}</Text>
     )
 }

--- a/client/src/commons/atoms/Typography.tsx
+++ b/client/src/commons/atoms/Typography.tsx
@@ -1,0 +1,31 @@
+/* 2023-07-04 홈페이지 내 모든 텍스트 styled - 김다함 */
+import { styled } from 'styled-components';
+import tw from 'twin.macro'
+
+const Span = styled.span<{ color?: string }>`
+    ${tw`align-middle`}
+    color: ${(props) => props.color};
+`
+
+// 제목 텍스트 스타일 컴포넌트
+export const HeadingText = styled.h1`
+    margin: 0;
+`;
+
+// 라벨 텍스트 스타일 컴포넌트
+export const LabelText = styled.h3`
+    margin: 0;
+`;
+
+// 본문 텍스트 스타일 컴포넌트
+export const BodyText = styled.span`
+`;
+
+export const InputLabelText = styled(Span)`
+    font-size: 16px;
+    font-weight: 600;
+`
+
+export const SmallText = styled(Span)`
+    font-size: 13px;
+`

--- a/client/src/commons/atoms/buttons/category/CategoryButton.tsx
+++ b/client/src/commons/atoms/buttons/category/CategoryButton.tsx
@@ -1,3 +1,4 @@
+/* 2023-07-02 메인(카테고리)페이지 카테고리 navBar의 낱개 버튼 - 김다함*/
 import 'styled-components/macro';
 import tw from 'twin.macro';
 import { styled } from 'styled-components';
@@ -23,7 +24,7 @@ const Category = styled.button`
     }
 `
 
-export default function CategoryButton({category}:CategoryBtnProps){
+export default function CategoryButton({ category }: CategoryBtnProps) {
 
     return (
         <Category>{category}</Category>

--- a/client/src/commons/atoms/dropdown/DropDownBox.tsx
+++ b/client/src/commons/atoms/dropdown/DropDownBox.tsx
@@ -1,0 +1,27 @@
+/* 2023.07.05 드롭다운 박스(접혔을 때 본체) - 김다함 */
+import { ReactNode } from 'react';
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+import { BiCaretDown, BiCaretUp } from "react-icons/bi";
+import { FlexContainer } from '@/commons/styles/Containers.styled';
+
+interface DropDownProps {
+    value: string;
+}
+
+const DropDownBoxContainer = styled.div`
+    ${tw`w-28 px-3 py-1.5 text-sm flex justify-between select-none`}
+
+    border: 1px solid #C3C3C3;
+    background-color: #3A3B41;
+    color: white;
+`;
+
+export default function DropDownBox({ value }: DropDownProps) {
+    return (
+        <DropDownBoxContainer>
+            {value}
+            {'isOpen' ? <BiCaretUp /> : <BiCaretDown />}
+        </DropDownBoxContainer>
+    )
+}

--- a/client/src/commons/atoms/dropdown/DropDownItem.tsx
+++ b/client/src/commons/atoms/dropdown/DropDownItem.tsx
@@ -1,0 +1,24 @@
+/* 2023.07.05 드롭다운 아이템(펼쳤을 때 나오는 옵션들) - 김다함 */
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+
+interface DropDownItemProps {
+    value: string;
+}
+
+const DropDownItemContainer = styled.div`
+    ${tw`px-3 py-2 text-xs bg-transparent select-none`}
+    color: white;
+    &:hover {
+        background-color: #5e5e5e;
+    }
+    cursor: pointer;
+`;
+
+export default function DropDownItem({ value }: DropDownItemProps) {
+    return (
+        <DropDownItemContainer>
+            {value}
+        </DropDownItemContainer>
+    )
+}

--- a/client/src/commons/atoms/header/CHeader.styled.tsx
+++ b/client/src/commons/atoms/header/CHeader.styled.tsx
@@ -15,6 +15,8 @@ export const BtnContainer = tw.div`
 `;
 
 export const RecuitBtn = tw.button`
+  cursor-pointer
+  text-xs
   mr-3
   hover:underline
 `;

--- a/client/src/commons/molecules/CategoryDropDown.tsx
+++ b/client/src/commons/molecules/CategoryDropDown.tsx
@@ -1,0 +1,33 @@
+/* 2023-07-04 게시물 카테고리 선택 드롭다운 컴포넌트 - 김다함 */
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+import DropDownBox from '../atoms/dropdown/DropDownBox';
+import DropDownItem from '../atoms/dropdown/DropDownItem';
+import { FlexColumnWrapper } from '../styles/Containers.styled';
+
+export const DropDownItemContainer = styled.div`
+    ${tw`w-28 flex flex-col z-10 absolute`}
+    border: 1px solid #C3C3C3;
+    border-top: 0;
+    background-color: rgba(72, 72, 72, 0.9);
+    top: 117px;
+`;
+
+export const ContegroyDropDown = () => {
+    return (
+        <FlexColumnWrapper gap={0}>
+            <DropDownBox value={'웹'} />
+            {'isOpened' &&
+                <DropDownItemContainer>
+                    <DropDownItem value='앱' />
+                    <DropDownItem value='웹' />
+                    <DropDownItem value='3D/애니메이션' />
+                    <DropDownItem value='디자인/일러스트' />
+                    <DropDownItem value='사진/영상' />
+                </DropDownItemContainer>
+            }
+        </FlexColumnWrapper>
+    )
+}
+
+export default ContegroyDropDown;

--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -1,6 +1,4 @@
-/* 2023-07-05 게시물 카테고리 선택 드롭다운 컴포넌트 - 김다함 */
-import { styled } from 'styled-components';
-import tw from 'twin.macro';
+/* 2023-07-05 게시물 댓글(낱개) 컴포넌트 - 김다함 */
 import { FlexColumnContainer, FlexWrapper } from '../styles/Containers.styled';
 import UserProfile from './UserProfile';
 import ReviseBtn from '../atoms/buttons/revise-remove/ReviseBtn';
@@ -15,7 +13,7 @@ interface CommentProps {
 
 export default function Comment({ username, content, date }: CommentProps) {
     return (
-        <FlexColumnContainer gap={10} className='w-full border-b-[1px] pb-2'>
+        <FlexColumnContainer gap={10} className='w-full border-b-[1px] pb-1.5 pt-3'>
             <FlexWrapper gap={0} className='w-full justify-between'>
                 <UserProfile type='comment' username={username} />
                 <FlexWrapper gap={0}>

--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -1,0 +1,32 @@
+/* 2023-07-05 게시물 카테고리 선택 드롭다운 컴포넌트 - 김다함 */
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+import { FlexColumnContainer, FlexWrapper } from '../styles/Containers.styled';
+import UserProfile from './UserProfile';
+import ReviseBtn from '../atoms/buttons/revise-remove/ReviseBtn';
+import RemoveBtn from '../atoms/buttons/revise-remove/RemoveBtn';
+import { BodyText, SmallText } from '../atoms/Typography';
+
+interface CommentProps {
+    username: string;
+    content: string;
+    date: string;
+}
+
+export default function Comment({ username, content, date }: CommentProps) {
+    return (
+        <FlexColumnContainer gap={10} className='w-full border-b-[1px] pb-2'>
+            <FlexWrapper gap={0} className='w-full justify-between'>
+                <UserProfile type='comment' username={username} />
+                <FlexWrapper gap={0}>
+                    <ReviseBtn />
+                    <RemoveBtn />
+                </FlexWrapper>
+            </FlexWrapper>
+            <FlexWrapper gap={0} className='w-full justify-between'>
+                <BodyText>{content}</BodyText>
+                <SmallText color='gray'>{date}</SmallText>
+            </FlexWrapper>
+        </FlexColumnContainer>
+    )
+}

--- a/client/src/commons/molecules/CommentWriteBox.tsx
+++ b/client/src/commons/molecules/CommentWriteBox.tsx
@@ -1,0 +1,17 @@
+/* 2023-07-05 게시물 댓글 작성란 컴포넌트 - 김다함 */
+import { FlexColumnContainer, FlexWrapper } from '../styles/Containers.styled';
+import UserProfile from './UserProfile';
+import { TextArea } from '@/commons/styles/Inputs.styled';
+import SaveBtn from '../atoms/buttons/writing/SaveBtn';
+
+export default function CommentWriteBox() {
+    return (
+        <FlexColumnContainer gap={5} className='w-full bt-[1px] mt-10'>
+            <FlexWrapper gap={0} className='w-full justify-between'>
+                <UserProfile type='comment' username='ehyo' date='39-29-39' />
+                <SaveBtn />
+            </FlexWrapper>
+            <TextArea className='w-full h-20' />
+        </FlexColumnContainer>
+    )
+} 

--- a/client/src/commons/molecules/IconInput.tsx
+++ b/client/src/commons/molecules/IconInput.tsx
@@ -1,8 +1,0 @@
-const IconInput = () => {
-    return(
-        <>
-        </>
-    )
-}
-
-export default IconInput;

--- a/client/src/commons/molecules/Tag.tsx
+++ b/client/src/commons/molecules/Tag.tsx
@@ -1,0 +1,48 @@
+/* 2023-07-05 태그 컴포넌트 - 김다함 */
+import { styled, css } from 'styled-components';
+import tw from 'twin.macro';
+import { RxDotFilled } from 'react-icons/rx';
+
+interface TagProps {
+    value: string;
+    isSelected?: boolean;
+}
+
+const tagStye = css`
+    ${tw`w-fit py-1.5 px-2.5 rounded-full select-none flex`}
+`
+
+const TagBody = styled.div<{ isSelected?: boolean }>`
+    ${tagStye}
+    background-color: #484848;
+    border: 0.9px solid #C3C3C3;
+    color: white;
+    cursor: pointer;
+    &:hover {
+        border-color: #dcdcdc;
+    }
+
+    ${(props) => props.isSelected &&
+        css`
+            border-color: #dcdcdc;
+            background-color: white;
+            color: #232428;
+        `
+    }
+
+    .dot {
+        vertical-align: middle;
+        color: #484848;
+    }
+`;
+
+export const Tag = ({ value, isSelected }: TagProps) => {
+    return (
+        <TagBody isSelected={isSelected}>
+            <p className='text-xs'>{value}</p>
+            {isSelected && <RxDotFilled className='dot' />}
+        </TagBody>
+    )
+}
+
+export default Tag;

--- a/client/src/commons/molecules/UserProfile.tsx
+++ b/client/src/commons/molecules/UserProfile.tsx
@@ -14,34 +14,34 @@ import userImg from '@/assets/userImg.jpg';
 // mini, middle, large
 
 interface UserProfileProps {
-    type: string;
+    type: 'board' | 'comment' | 'portfolio';
     username: string;
     date?: string;
 }
 
-const ImageSizes:any = {
+const ImageSizes: any = {
     board: 65,
     comment: 35,
     portfolio: 100,
 }
 
-const LabelSizes:any = {
+const LabelSizes: any = {
     board: 20,
     comment: 12,
     portfolio: 30
 }
 
-const UserProfile = ({type, username, date}:UserProfileProps)=>{
+const UserProfile = ({ type, username, date }: UserProfileProps) => {
     return (
         <FlexContainer gap={15}>
-            <Image url={userImg} shape='circle' size={ImageSizes[type]}/>
-            { type === 'board' ?
+            <Image url={userImg} shape='circle' size={ImageSizes[type]} />
+            {type === 'board' ?
                 <FlexColumnWrapper gap={0}>
-                    <Label text={username} size={LabelSizes[type]}/>
+                    <Label text={username} size={LabelSizes[type]} />
                     <span>{date}2022.06.30</span>
                 </FlexColumnWrapper>
                 :
-                <Label text={username} size={LabelSizes[type]}/>
+                <Label text={username} size={LabelSizes[type]} />
             }
         </FlexContainer>
     )

--- a/client/src/commons/styles/Buttons.styled.tsx
+++ b/client/src/commons/styles/Buttons.styled.tsx
@@ -1,0 +1,27 @@
+/* 2023-07-05 홈페이지 내 들어가는 모든 버튼 styled - 김다함*/
+import { styled, css } from 'styled-components';
+import tw from 'twin.macro';
+
+const CircleBtn = css`
+    ${tw`rounded-full inline-flex justify-center items-center`}
+`
+
+export const PortfolioEditButton = styled.button<{ type: 'light' | 'dark' }>`
+    ${CircleBtn}
+    width: 63px;
+    height: 63px;
+    ${(props) => props.type === 'light' ?
+        css`
+            background-color: rgba(71, 70, 70, 0.62);
+            border: 1px solid #EFEFEF;
+            &:hover{
+                background-color: rgba(81, 80, 80, 0.62);
+            }
+        `
+        :
+        css`
+            background-color: white;
+            border: 1px solid white;
+        `
+    }
+`

--- a/client/src/commons/styles/Containers.styled.tsx
+++ b/client/src/commons/styles/Containers.styled.tsx
@@ -1,3 +1,4 @@
+/* 2023.07.03 컴포넌트, 페이지에 전체적으로 쓰이는 정렬 컨테이너 - 김다함 */
 import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
@@ -11,7 +12,12 @@ export const FlexColumnContainer = styled.div<{ gap: number }>`
   gap: ${(props) => props.gap}px;
 `;
 
-export const FlexColumnWrapper = styled.div<{gap: number}>`
-  ${tw`flex flex-col `}
+export const FlexWrapper = styled.div<{ gap: number }>`
+  ${tw`flex`}
+  gap: ${(props) => props.gap}px;
+`
+
+export const FlexColumnWrapper = styled.div<{ gap: number }>`
+  ${tw`flex flex-col`}
   gap: ${(props) => props.gap}px;
 `

--- a/client/src/commons/styles/Inputs.styled.tsx
+++ b/client/src/commons/styles/Inputs.styled.tsx
@@ -1,10 +1,16 @@
 /* 2023-07-04 홈페이지에 들어가는 모든 Input styled - 김다함*/
-import { styled, css } from 'styled-components';
+import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
-const Input = styled.input`
+export const Input = styled.input`
     ${tw`w-full border-0`}
 `;
+
+export const TextArea = styled.textarea`
+    ${tw`resize-none rounded-md border-[1px]`}
+    &:focus {outline: none;}
+    font-size: 13px;
+`
 
 export const PortfolioTitleInput = styled(Input)`
     ${tw`bg-transparent text-4xl`}
@@ -14,10 +20,9 @@ export const PortfolioTitleInput = styled(Input)`
     }
 `;
 
-export const TextArea = styled.textarea`
-    ${tw`resize-none outline-0 rounded-md`}
+export const DarkTextArea = styled(TextArea)`
+    outline: none;
     box-shadow: inset 0px 0px 33px -6px #111111;
     background-color: #3A3B41;
-    font-size: 13px;
     color: white;
 `;

--- a/client/src/commons/styles/Inputs.styled.tsx
+++ b/client/src/commons/styles/Inputs.styled.tsx
@@ -1,0 +1,23 @@
+/* 2023-07-04 홈페이지에 들어가는 모든 Input styled - 김다함*/
+import { styled, css } from 'styled-components';
+import tw from 'twin.macro';
+
+const Input = styled.input`
+    ${tw`w-full border-0`}
+`;
+
+export const PortfolioTitleInput = styled(Input)`
+    ${tw`bg-transparent text-4xl`}
+    color: white;
+    &:focus{
+        ${tw`outline-0`}
+    }
+`;
+
+export const TextArea = styled.textarea`
+    ${tw`resize-none outline-0 rounded-md`}
+    box-shadow: inset 0px 0px 33px -6px #111111;
+    background-color: #3A3B41;
+    font-size: 13px;
+    color: white;
+`;

--- a/client/src/commons/styles/StyleList.ts
+++ b/client/src/commons/styles/StyleList.ts
@@ -1,3 +1,4 @@
+/* 2023-07-04 디자인 토큰 대신 사용할까 고민중이나 아직 불필요해서 보류 - 김다함*/
 import { ProfileType } from '@/types/StyleType';
 
 export const profileTypes: ProfileType = {

--- a/client/src/components/CommentBox.tsx
+++ b/client/src/components/CommentBox.tsx
@@ -1,0 +1,21 @@
+/* 2023-07-05 게시물 상세보기 페이지 댓글 영역 컴포넌트 - 김다함 */
+import Card from '@/commons/atoms/Card';
+import Comment from '@/commons/molecules/Comment';
+import { FlexColumnContainer } from '@/commons/styles/Containers.styled';
+import CommentWriteBox from '@/commons/molecules/CommentWriteBox';
+
+interface CommentBoxProps {
+    comment: 'CommentType'
+}
+
+export default function CommentBox({ comment }: CommentBoxProps) {
+    return (
+        <Card className='justify-between'>
+            <FlexColumnContainer gap={0}>
+                <Comment username='vite' content='zzzzz' date='2020-20-20' />
+                <Comment username='vite' content='zzzzz' date='2020-20-20' />
+            </FlexColumnContainer>
+            <CommentWriteBox />
+        </Card>
+    )
+} 

--- a/client/src/components/edit/TitleForm.tsx
+++ b/client/src/components/edit/TitleForm.tsx
@@ -1,5 +1,5 @@
 /* 2023-07-04 포트폴리오 작성/수정 페이지 제목,태그 작성 Form - 김다함 */
-import { TextArea } from '@/commons/styles/Inputs.styled';
+import { DarkTextArea } from '@/commons/styles/Inputs.styled';
 import { InputLabelText, SmallText } from '@/commons/atoms/Typography';
 import ContegroyDropDown from '@/commons/molecules/CategoryDropDown';
 import Tag from '@/commons/molecules/Tag';
@@ -44,7 +44,7 @@ const TitleForm = ({ isCreated }: TitleFormProps) => {
                 </div>
                 <InputLabelText color='#c8c9cc'>소개글</InputLabelText>
                 <div className='flex justify-between'>
-                    <TextArea className='w-[42%] h-20' />
+                    <DarkTextArea className='w-[42%] h-20' />
                     <FlexWrapper gap={15}>
                         <PortfolioEditButton type='light'><RiArrowGoBackFill size='25' color='white' /></PortfolioEditButton>
                         <PortfolioEditButton type='dark'><BsCheck2 size='25' color='black' /></PortfolioEditButton>

--- a/client/src/components/edit/TitleForm.tsx
+++ b/client/src/components/edit/TitleForm.tsx
@@ -1,0 +1,58 @@
+/* 2023-07-04 포트폴리오 작성/수정 페이지 제목,태그 작성 Form - 김다함 */
+import { TextArea } from '@/commons/styles/Inputs.styled';
+import { InputLabelText, SmallText } from '@/commons/atoms/Typography';
+import ContegroyDropDown from '@/commons/molecules/CategoryDropDown';
+import Tag from '@/commons/molecules/Tag';
+import { FlexColumnWrapper, FlexWrapper } from '@/commons/styles/Containers.styled';
+import { PortfolioTitleInput } from '@/commons/styles/Inputs.styled';
+import { styled } from 'styled-components';
+import tw from 'twin.macro';
+import { PortfolioEditButton } from '@/commons/styles/Buttons.styled';
+import { RiArrowGoBackFill } from 'react-icons/ri';
+import { BsCheck2 } from 'react-icons/bs';
+
+interface TitleFormProps {
+    isCreated: string;
+}
+
+const TitleFormContainer = styled.div`
+    ${tw`w-screen px-16 py-7 rounded-t-2xl`};
+    background-color: #161616;
+    box-shadow: 0 -8px 10px -1px #a9a9a9;
+`;
+
+const TitleForm = ({ isCreated }: TitleFormProps) => {
+    return (
+        <TitleFormContainer>
+            <FlexColumnWrapper gap={15}>
+                <PortfolioTitleInput placeholder='Title' />
+                <FlexWrapper gap={10}>
+                    <ContegroyDropDown />
+                    <SmallText color='white' className='pt-2'>{isCreated}</SmallText>
+                </FlexWrapper>
+                <div className='flex gap-1.5 w-[40%] flex-wrap z-0'>
+                    {/* 예시 */}
+                    <Tag value='JavaScript' isSelected={true} />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' isSelected={true} />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' />
+                    <Tag value='JavaScript' />
+                </div>
+                <InputLabelText color='#c8c9cc'>소개글</InputLabelText>
+                <div className='flex justify-between'>
+                    <TextArea className='w-[42%] h-20' />
+                    <FlexWrapper gap={15}>
+                        <PortfolioEditButton type='light'><RiArrowGoBackFill size='25' color='white' /></PortfolioEditButton>
+                        <PortfolioEditButton type='dark'><BsCheck2 size='25' color='black' /></PortfolioEditButton>
+                    </FlexWrapper>
+                </div>
+            </FlexColumnWrapper>
+        </TitleFormContainer>
+    )
+}
+
+export default TitleForm;

--- a/client/src/components/navbar/CategoryNavBar.tsx
+++ b/client/src/components/navbar/CategoryNavBar.tsx
@@ -1,8 +1,8 @@
+/* 2023-07-02 메인(카테고리)페이지 카테고리 navBar 컴포넌트 - 김다함*/
 import CategoryButton from '@/commons/atoms/buttons/category/CategoryButton';
 import { FlexContainer } from '@/commons/styles/Containers.styled';
 
-
-export default function CategoryNavBar(){
+export default function CategoryNavBar() {
     const Categories = [
         "웹",
         "앱",
@@ -14,8 +14,8 @@ export default function CategoryNavBar(){
     return (
         <FlexContainer gap={20}>
             {
-                Categories.map((category)=>{
-                    return <CategoryButton category={category}/>
+                Categories.map((category) => {
+                    return <CategoryButton category={category} />
                 })
             }
         </FlexContainer>

--- a/client/src/stories/atoms/buttons/Buttons.stories.tsx
+++ b/client/src/stories/atoms/buttons/Buttons.stories.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import CategoryButton, {CategoryBtnProps} from '../../commons/atoms/buttons/category/CategoryButton';
+import CategoryButton, { CategoryBtnProps } from '../../../commons/atoms/buttons/category/CategoryButton';
 import { Meta } from "@storybook/react"
 
 export default {
@@ -8,10 +8,10 @@ export default {
     argTypes: {
         mode: {
             options: ['DarkMode', 'LightMode'],
-            control: {type: 'radio'}
+            control: { type: 'radio' }
         }
     }
-}as Meta;
+} as Meta;
 
-export const CategoryBtn = (args:CategoryBtnProps) => <CategoryButton {...args}/>
+export const CategoryBtn = (args: CategoryBtnProps) => <CategoryButton {...args} />
 CategoryBtn.args = { category: '웹' };

--- a/client/src/stories/components/DropDown.stories.tsx
+++ b/client/src/stories/components/DropDown.stories.tsx
@@ -1,0 +1,15 @@
+import ContegroyDropDown from '@/commons/molecules/CategoryDropDown';
+import { Meta } from '@storybook/react';
+
+export default {
+    title: 'Components/DropDown',
+    component: ContegroyDropDown,
+    argTypes: {
+        mode: {
+            options: ['DarkMode', 'LightMode'],
+            control: { type: 'radio' },
+        },
+    },
+} as Meta;
+
+export const CategoryDropDown = (args: any) => <ContegroyDropDown {...args} />;

--- a/client/src/stories/components/Form.stories.tsx
+++ b/client/src/stories/components/Form.stories.tsx
@@ -1,0 +1,18 @@
+import TitleForm from '@/components/edit/TitleForm';
+import { Meta } from '@storybook/react';
+
+export default {
+    title: 'Components/Form',
+    component: TitleForm,
+    argTypes: {
+        mode: {
+            options: ['DarkMode', 'LightMode'],
+            control: { type: 'radio' },
+        },
+    },
+} as Meta;
+
+export const TitleAndTagsForm = (args: any) => <TitleForm {...args} />;
+TitleAndTagsForm.args = {
+    isCreated: '2023-07-05-WED',
+}

--- a/client/src/stories/components/Tags.stories.tsx
+++ b/client/src/stories/components/Tags.stories.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import Tag from '@/commons/molecules/Tag';
+import { Meta } from "@storybook/react"
+
+export default {
+    title: 'Components/Tag',
+    component: Tag,
+    argTypes: {
+        mode: {
+            options: ['DarkMode', 'LightMode'],
+            control: { type: 'radio' }
+        }
+    }
+} as Meta;
+
+export const PortfolioTag = (args: any) => <Tag {...args} />
+PortfolioTag.args = {
+    value: 'JavaScript',
+    isSelected: true
+};

--- a/client/src/stories/components/UserProfile.stories.tsx
+++ b/client/src/stories/components/UserProfile.stories.tsx
@@ -1,32 +1,62 @@
-import UserProfile from '../../commons/molecules/UserProfile';
+import Label from '@/commons/atoms/Label';
+import UserProfile from '@/commons/molecules/UserProfile';
+import Image from '@/commons/atoms/Image';
+import userImg from '@/assets/userImg.jpg';
+import { FlexColumnWrapper, FlexContainer } from '@/commons/styles/Containers.styled';
 import { Meta } from '@storybook/react';
 
 export default {
     title: 'Components/UserProfile',
     component: UserProfile,
     argTypes: {
-    type: {
-        options: ['board', 'comment', 'portfolio'],
-        control: { type: 'select' },
+        type: {
+            options: ['board', 'comment', 'portfolio'],
+            control: { type: 'select' },
+        },
     },
-},
 } as Meta;
 
-export const BoardProfile = (args: any) => <BoardProfile {...args} />;
+const ImageSizes:any = {
+    board: 65,
+    comment: 35,
+    portfolio: 100,
+}
+
+const LabelSizes:any = {
+    board: 20,
+    comment: 12,
+    portfolio: 30
+}
+
+const Template: any = (args:any) => (
+    <FlexContainer gap={15}>
+        <Image url={userImg} shape='circle' size={ImageSizes[args.type]}/>
+        { args.type === 'board' ?
+            <FlexColumnWrapper gap={0}>
+                <Label text={args.username} size={LabelSizes[args.type]}/>
+                <span>{args.date}</span>
+            </FlexColumnWrapper>
+            :
+            <Label text={args.username} size={LabelSizes[args.type]}/>
+        }
+    </FlexContainer>
+);
+
+export const BoardProfile = Template.bind({});
 BoardProfile.args = {
     type:'board',
-    username:'hello',
+    username:'username',
     date:'2020.06.21'
 }
 
-export const CommentProfile = (args: any) => <CommentProfile {...args} />;
+export const CommentProfile = Template.bind({});
 CommentProfile.args = {
     type:'comment',
-    username:'hello',
+    username:'username',
 }
 
-export const PofolProfile = (args: any) => <PofolProfile {...args} />;
+export const PofolProfile = Template.bind({});
 CommentProfile.args = {
     type:'portfolio',
-    username:'hello',
+    username:'username',
 }

--- a/client/src/types/StyleType.ts
+++ b/client/src/types/StyleType.ts
@@ -1,3 +1,4 @@
+/* 2023-07-04 글로벌토큰 대체용 스타일에 사용되는 type - 김다함 */
 export type ProfileType = {
     [key: string]: {
         fontSize: string
@@ -6,6 +7,6 @@ export type ProfileType = {
 
 export type ProfileImageType = {
     [key: string]: {
-        
+
     }
 }


### PR DESCRIPTION
# 개요
* 게시물 상세보기 페이지에 존재하는 댓글 컴포넌트를 작업했습니다.

# 작업내용
* `commons/atoms/Card` - 하얀색 둥근 border-radius를 가진 카드 컴포넌트입니다.
* `commons/molecules/Comment` - 댓글 아이템 한 개의 컴포넌트입니다.
* `commons/molecules/CommentWriteBox` - 댓글 작성란 컴포넌트입니다.
* `components/CommentBox` - 게시물 상세보기 페이지 우측에 존재하는 댓글 컴포넌트입니다.

# 결과 화면
<img width="1728" alt="image" src="https://github.com/codestates-seb/seb44_main_013/assets/81691456/f8edad14-a6f5-4b33-b774-0dc33f7e9c3f">

## 참고사항
* 제가 폭을 full로 한 이유는 페이지를 추합하실 때 글 부분과 댓글 부분이 어떤 비율로 나눠질지 몰라 페이지 정렬하는 컨테이너 비율에 맞게 크기가 조정되도록 만든 것입니다.(세로 길이도 더 길게 고정시키면 justify-between으로 해놔서 댓글이 적을 경우에 댓글 작성란과 거리가 띄워질 겁니다.)
* 각 컴포넌트마다 존재하는 interface 정의는 기능 구현 시 객체로 정리하시면 됩니다. 그냥 당장 브라우저에 그리기 위해 필요한 데이터 하나하나를 나열했습니다. `comment: 'CommentProps'` 와 같이 문자열로 표현한 건 나중에 저런 식으로 객체를 분리해 타입으로 받으면 된다는 걸 명시하는 목적으로 적은 겁니다.
* 피그마에 댓글 페이지네이션 빠져있는 거 뒤늦게 깨달았는데 당장 제가 pull 한 컴포넌트에는 아직 페이지네이션 컴포넌트가 없어서, 일단 빼둔채로 push합니다. 나중에 기능 구현하시는 분이 넣어도 충분할 것 같습니다.