### PR TITLE
Design: mypage 추합 작업

### DIFF
--- a/client/src/commons/atoms/footer/Footer.styled.tsx
+++ b/client/src/commons/atoms/footer/Footer.styled.tsx
@@ -7,7 +7,6 @@ export const FooterContainer = tw.div`
   justify-center 
   items-center 
   h-14
-  mt-10
 `;
 
 export const FooterText = tw.div`

--- a/client/src/components/mypage-community/CommunityList.styled.tsx
+++ b/client/src/components/mypage-community/CommunityList.styled.tsx
@@ -1,18 +1,20 @@
 import tw from 'tailwind-styled-components';
 
 export const Wrapper = tw.div`
-  mt-5
-  w-1/2
+  mt-2
+  ml-2
+  w-full
   h-[50px]
   bg-zinc-400	
   flex
-  rounded-xl
+  rounded-md
   items-center
   justify-between
   transition-transform
   duration-200
   ease-in-out
-  hover:scale-105
+  hover:bg-zinc-700
+  cursor-pointer
 `;
 
 export const TextContainer = tw.div`

--- a/client/src/components/mypageItem/MypageItem.styled.tsx
+++ b/client/src/components/mypageItem/MypageItem.styled.tsx
@@ -25,7 +25,7 @@ export const ImgEx = styled.div`
         py-3
         text-ITEM_TITLE
         relative
-        -translate-y-[75px]
+        -translate-y-[73px]
         w-48
         flex
         flex-col

--- a/client/src/components/mypageProfile/MypageProfile.styled.tsx
+++ b/client/src/components/mypageProfile/MypageProfile.styled.tsx
@@ -8,6 +8,7 @@ export const MypageProfileContainer = styled.div`
     rounded-lg
     text-center
     p-7
+    mr-5
   `}
   width: 350px;
   height: 350px;

--- a/client/src/components/mypageProfile/MypageProfile.tsx
+++ b/client/src/components/mypageProfile/MypageProfile.tsx
@@ -42,5 +42,5 @@ export default function MypageProfile () {
       </div>
     </MypageProfileContainer>
   );
-};
+}
 

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -5,12 +5,12 @@
 /* scroll width */
 ::-webkit-scrollbar {
     width: 5px;
-    height: 4px
+    height: 5px
 }
 
 /* Track */
 ::-webkit-scrollbar-track {
-    background: transparent;
+    background: rgba(255,255,255,20%);
 }
 
 /* Handle */

--- a/client/src/pages/mypage/MyPage.styled.tsx
+++ b/client/src/pages/mypage/MyPage.styled.tsx
@@ -1,29 +1,38 @@
 import tw from 'twin.macro'
+import { styled } from 'styled-components'
 
 export const MainWrapper = tw.div`
   bg-BASIC_BLACK
     w-screen
-    h-screen
+    h-full
     flex
     flex-col
     justify-center
+    p-4
 `;
 
 export const MyItemsWrapper = tw.div`
     h-fit
+    flex
+    flex-col
+    justify-center
+    m-auto
 `;
 
-export const BoxWrapper = tw.div`
-    w-8/12
-    h-[240px]
-    py-3
-    pr-5
-     bg-pink-300
-    flex
-    flex-row
-    overflow-x-scroll
-    mb-5
-    ml-2
+export const BoxWrapper = styled.div< {isRow?: string} >`
+    ${ tw`
+        w-[1050px]
+        h-[240px]
+        py-3
+        pr-5
+        flex
+        mb-5
+        ml-2
+    `}
+    flex-direction:${(props) => (props.isRow ? 'column' : 'row')};
+    overflow: ${(props) => (props.isRow ? 'none' : 'auto')};
+    height: ${(props) => (props.isRow ? '380px' : '240px')}
+   
 `;
 
 export const BoxTitle = tw.div`
@@ -31,4 +40,14 @@ export const BoxTitle = tw.div`
     text-xl
     text-BASIC_WHITE
     ml-4
+    mt-10
+`;
+
+//MyProfile 
+export const MyProfileWrapper = tw.div`
+    flex
+    flex-row
+    justify-center
+    mt-3
+    mb-10
 `;

--- a/client/src/pages/mypage/Mypage.tsx
+++ b/client/src/pages/mypage/Mypage.tsx
@@ -1,7 +1,10 @@
-import React, {useState} from 'react';
+import {useState} from 'react';
 import MypageItem from "@/components/mypageItem/MypageItem";
-import { BoxTitle, BoxWrapper, MainWrapper, MyItemsWrapper } from "./MyPage.styled";
+import { BoxTitle, BoxWrapper, MainWrapper, MyItemsWrapper, MyProfileWrapper } from "./MyPage.styled";
 import { FlexColumnWrapper } from '@/commons/styles/Containers.styled';
+import MypageProfile from '@/components/mypageProfile/MypageProfile';
+import MypageIntroduce from '@/components/mypageIntroduce/MypageIntroduce';
+import CommunityList from '@/components/mypage-community/CommunityList';
 
 
 export default function MyPage () {
@@ -9,12 +12,15 @@ export default function MyPage () {
 
     return(
         <MainWrapper>
+            
             {/* 프로필 부분  */}
+            <MyProfileWrapper>
+                <MypageProfile/>
+                <MypageIntroduce/>
+            </MyProfileWrapper>
 
-
-            {/* {}안에 서버로부터 받아온 정보를 보내주면 됩니다. */}
             <MyItemsWrapper>
-
+                {/* {}안에 서버로부터 받아온 정보를 보내주면 됩니다. */}
                 <FlexColumnWrapper gap={0}>
                     <BoxTitle>게시물</BoxTitle>
                     <BoxWrapper>
@@ -27,7 +33,9 @@ export default function MyPage () {
                 </FlexColumnWrapper>
                 
                 { isUser ? 
-                (   <FlexColumnWrapper gap={0}>
+                (   
+
+                    <FlexColumnWrapper gap={0}>
                         <BoxTitle>북마크</BoxTitle>
                         <BoxWrapper>
                             {Array.from({length:10}).map((_, index) => {
@@ -39,6 +47,14 @@ export default function MyPage () {
 
                         {/* 게시판 목록 부분  */}
 
+                        <BoxTitle>게시판</BoxTitle>
+                        <BoxWrapper isRow="column">
+                            {Array.from({length:5}).map((_, index) => {
+                                return(
+                                    <CommunityList key={index}/>
+                                )
+                            })}
+                        </BoxWrapper>
                     </FlexColumnWrapper>
                 ) 
                 : null }


### PR DESCRIPTION
# 개요 
마이 페이지 추합 작업 PR 입니다. 

# 작업 사항 
1. 내가 쓴 글의 목록 부분의 아이템
     * Hover 효과 사이즈 증가 -> 색상 변경 
     * width  길이 고정  
2. 전체적인 구조 justify-center 고정 
3. 내 게시물과 좋아요 게시물 의 경우는 가로 스크롤 
4. 게시판 목록은 추후 페이지네이션 적용 예정

# 스크린 샷 
![스크린샷 2023-07-06 오전 9 14 10](https://github.com/codestates-seb/seb44_main_013/assets/110151638/5d0cce27-ab7a-4811-a900-c73905232b71)

![스크린샷 2023-07-06 오전 9 14 15](https://github.com/codestates-seb/seb44_main_013/assets/110151638/8115ee4d-3c24-4ee0-9f8d-262ad7184edd)

# 추가 작업 필요 사항 
게시판 목록의  페이지네이션 구현이 필요합니다. 
![스크린샷 2023-07-06 오전 9 33 15](https://github.com/codestates-seb/seb44_main_013/assets/110151638/f4ca487b-8d72-457b-80a8-a0464ff77252)
