### PR TITLE
[FRONT] 포트폴리오 상세보기 페이지 태그 추가 & 정렬 간격 수정

### DIFF
--- a/client/src/commons/atoms/Label.tsx
+++ b/client/src/commons/atoms/Label.tsx
@@ -2,20 +2,26 @@
 import { styled } from 'styled-components';
 
 interface LabelProps {
-    text: string;
-    size: number;
+  text: string;
+  type: string;
 }
 
-const Text = styled.label<{ size: number }>`
+const LabelSizes: any = {
+  board: 20,
+  comment: 12,
+  portfolio: 30
+}
+
+const Text = styled.label<{ size: string, type: string }>`
     font-size: ${(props) => props.size}px;
     font-weight: 600;
-    color: #232629;
+    color: ${(props) => props.type === 'portfolio' ? 'white' : '#232629'}
 `;
 
-const Label = ({ size, text }: LabelProps) => {
-    return (
-        <Text size={size}>{text}</Text>
-    )
+const Label = ({ type, text }: LabelProps) => {
+  return (
+    <Text size={LabelSizes[type]} type={type}>{text}</Text>
+  )
 }
 
 export default Label;

--- a/client/src/commons/molecules/UserProfile.tsx
+++ b/client/src/commons/molecules/UserProfile.tsx
@@ -14,37 +14,31 @@ import userImg from '@/assets/userImg.jpg';
 // mini, middle, large
 
 interface UserProfileProps {
-    type: 'board' | 'comment' | 'portfolio';
-    username: string;
-    date?: string;
+  type: 'board' | 'comment' | 'portfolio';
+  username: string;
+  date?: string;
 }
 
 const ImageSizes: any = {
-    board: 65,
-    comment: 35,
-    portfolio: 100,
-}
-
-const LabelSizes: any = {
-    board: 20,
-    comment: 12,
-    portfolio: 30
+  board: 65,
+  comment: 35,
+  portfolio: 100,
 }
 
 const UserProfile = ({ type, username, date }: UserProfileProps) => {
-    return (
-        <FlexContainer gap={15}>
-            <Image url={userImg} shape='circle' size={ImageSizes[type]} />
-            {type === 'board' ?
-                <FlexColumnWrapper gap={0}>
-                    <Label text={username} size={LabelSizes[type]} />
-                    <span>{date}2022.06.30</span>
-                </FlexColumnWrapper>
-                :
-                <Label text={username} size={LabelSizes[type]} />
-            }
-        </FlexContainer>
-    )
+  return (
+    <FlexContainer gap={15}>
+      <Image url={userImg} shape='circle' size={ImageSizes[type]} />
+      {type === 'board' ?
+        <FlexColumnWrapper gap={0}>
+          <Label text={username} type={type} />
+          <span>{date}2022.06.30</span>
+        </FlexColumnWrapper>
+        :
+        <Label text={username} type={type} />
+      }
+    </FlexContainer>
+  )
 }
 
 export default UserProfile;

--- a/client/src/pages/portfolio-detail/PortfolioDetail.styled.tsx
+++ b/client/src/pages/portfolio-detail/PortfolioDetail.styled.tsx
@@ -19,7 +19,8 @@ export const UserContainer = tw.div`
   w-1/3
   flex
   flex-col
-  
+  gap-10
+  px-8
 `;
 
 export const ButtonsWrapper = tw.div`
@@ -30,8 +31,6 @@ export const ButtonContainer = tw.div`
   flex
   justify-between
   items-center
-  ml-20
-  mr-20
   `;
 
 export const CenteredContainer = tw.div`
@@ -39,6 +38,6 @@ export const CenteredContainer = tw.div`
   flex-col
   items-center
   justify-center
-  mt-20
   text-white
+  gap-5
 `;

--- a/client/src/pages/portfolio-detail/PortfolioDetail.tsx
+++ b/client/src/pages/portfolio-detail/PortfolioDetail.tsx
@@ -14,6 +14,8 @@ import {
 import LikeBtn from '@/commons/atoms/buttons/LikeBtn';
 import Bookmark from '@/components/bookmark/Bookmark';
 import UserProfile from '@/commons/molecules/UserProfile';
+import { FlexWrapper } from '@/commons/styles/Containers.styled';
+import Tag from '@/commons/molecules/Tag';
 
 export default function PortfolioDetail() {
   return (
@@ -39,7 +41,16 @@ export default function PortfolioDetail() {
 
         <>Title</>
 
-        <>tags</>
+        <FlexWrapper gap={8} className='flex-wrap'>
+          <Tag value="sdfsdfsdlkjflksdjfl" />
+          <Tag value="jasdjlfsdjfva" />
+          <Tag value="java" />
+          <Tag value="javfsdfjsldjflksdjflksjdlkfjsda" />
+          <Tag value="java" />
+          <Tag value="jdslfjsdlfava" />
+          <Tag value="java" />
+          <Tag value="jsdflkjkava" />
+        </FlexWrapper>
       </UserContainer>
     </Wrapper>
   );


### PR DESCRIPTION
# 작업내용
* 포트폴리오 상세보기 페이지에 태그 컴포넌트 추가했습니다.
* 사용자 소개 부분 padding, gap 조금 추가하였습니다.

# 결과 화면
![image](https://github.com/codestates-seb/seb44_main_013/assets/81691456/7f6b9381-c3a9-4cfc-bd4c-3e2ec48db417)

# 참고사항
* 의뢰요청 버튼은 크기 큰 버전으로 어떻게 재사용하는지(PurpleBigBtn..?) 잘 모르겠어서 못 고쳤습니다ㅜ.ㅜ