### PR TITLE
Design: UI 추합 작업 4차 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -11,6 +11,7 @@ import MainLayout from './commons/styles/layout/MainLayout';
 import PortfolioDetail from './pages/portfolio-detail/PortfolioDetail';
 import PortfolioEdit from './pages/portfolio-edit/PortfolioEdit';
 import CHeaderLayout from './commons/styles/layout/CHeaderLayout';
+import AddCommunity from './pages/community-add/AddCommunity';
 
 const queryClient = new QueryClient();
 
@@ -27,7 +28,8 @@ const App = () => {
 
           <Route element={<CHeaderLayout />}>
             <Route path="/boards" element={<CommunityMain />} />
-            <Route path="/boards/detail" element={<CommunityDetail />} />
+            <Route path="/boards/detail" element={<CommunityDetail/>}/>
+            <Route path="/boards/edit" element={<AddCommunity/>}/>
           </Route>
 
           <Route path="/portfolios/:portfolioId" element={<PortfolioDetail />} />

--- a/client/src/commons/atoms/Label.tsx
+++ b/client/src/commons/atoms/Label.tsx
@@ -9,13 +9,15 @@ interface LabelProps {
 const LabelSizes: any = {
   board: 20,
   comment: 12,
-  portfolio: 30
+  portfolio: 30,
+  blackboard: 20
 }
 
 const Text = styled.label<{ size: string, type: string }>`
     font-size: ${(props) => props.size}px;
     font-weight: 600;
-    color: ${(props) => props.type === 'portfolio' ? 'white' : '#232629'}
+    color: ${(props) => props.type === 'portfolio' || props.type === 'comment' || props.type === 'blackboard'
+      ? 'white' : '#232629'}
 `;
 
 const Label = ({ type, text }: LabelProps) => {

--- a/client/src/commons/atoms/Typography.tsx
+++ b/client/src/commons/atoms/Typography.tsx
@@ -24,15 +24,16 @@ export const LabelText = tw(H)`
 `;
 
 // 본문 텍스트 스타일 컴포넌트
-export const BodyText = tw(Span)`
-  text-base
+export const BodyText = styled.span`
+    color:#ffff;
+    font-weight:200;
 `;
 
 export const InputLabelText = styled(Span)`
   font-size: 16px;
   font-weight: 600;
-`
+`;
 
 export const SmallText = styled(Span)`
   font-size: 13px;
-`
+`;

--- a/client/src/commons/atoms/buttons/revise-remove/RemoveBtn.tsx
+++ b/client/src/commons/atoms/buttons/revise-remove/RemoveBtn.tsx
@@ -1,5 +1,6 @@
+import { Styledprops } from '@/types';
 import { RecuitBtn } from '../../header/CHeader.styled';
 
-export default function RemoveBtn() {
-  return <RecuitBtn>삭제</RecuitBtn>;
+export default function RemoveBtn( props:Styledprops ) {
+  return <RecuitBtn {...props}>삭제</RecuitBtn>;
 }

--- a/client/src/commons/atoms/buttons/revise-remove/ReviseBtn.tsx
+++ b/client/src/commons/atoms/buttons/revise-remove/ReviseBtn.tsx
@@ -1,5 +1,6 @@
+import { Styledprops } from '@/types';
 import { RecuitBtn } from '../../header/CHeader.styled';
 
-export default function ReviseBtn() {
-  return <RecuitBtn>수정</RecuitBtn>;
+export default function ReviseBtn( props:Styledprops ) {
+  return <RecuitBtn {...props} >수정</RecuitBtn>;
 }

--- a/client/src/commons/atoms/header/CHeader.styled.tsx
+++ b/client/src/commons/atoms/header/CHeader.styled.tsx
@@ -1,4 +1,5 @@
-import tw from 'tailwind-styled-components';
+import tw from 'twin.macro';
+import { styled } from 'styled-components';
 
 export const HeaderContainer = tw.div`
   flex
@@ -17,12 +18,23 @@ export const BtnContainer = tw.div`
   items-center
 `;
 
-export const RecuitBtn = tw.button`
-  cursor-pointer
-  text-base
-  mr-3
-  hover:underline
+export const RecuitBtn = styled.button`
+  ${ tw`
+    cursor-pointer
+    ml-2.5
+    mt-1
+    hover:underline
+    text-sm
+    whitespace-nowrap
+  ` }
+  color: ${(props) => props.color ? props.color : 'white' };
+
+  &:hover {
+    color: #8580E1;
+  }
+
 `;
+
 export const CooperBtn = tw.button`
   ml-3
   mr-3

--- a/client/src/commons/atoms/header/CHeader.tsx
+++ b/client/src/commons/atoms/header/CHeader.tsx
@@ -15,7 +15,7 @@ export default function CHeader() {
         <Logo />
       </Link>
       <BtnContainer>
-        <RecuitBtn>Recruitment</RecuitBtn>|<CooperBtn>Cooperation</CooperBtn>
+        <RecuitBtn>Recruitment</RecuitBtn>&nbsp;&nbsp;|<CooperBtn>Cooperation</CooperBtn>
         <UserImg />
       </BtnContainer>
     </HeaderContainer>

--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -17,8 +17,8 @@ export default function Comment({ username, content, date }: CommentProps) {
             <FlexWrapper gap={0} className='w-full justify-between'>
                 <UserProfile type='comment' username={username} />
                 <FlexWrapper gap={0}>
-                    <ReviseBtn />
-                    <RemoveBtn />
+                    <ReviseBtn color={'#d4d4d8'} />
+                    <RemoveBtn color={'#d4d4d8'} />
                 </FlexWrapper>
             </FlexWrapper>
             <FlexWrapper gap={0} className='w-full justify-between'>

--- a/client/src/commons/molecules/UserProfile.tsx
+++ b/client/src/commons/molecules/UserProfile.tsx
@@ -14,7 +14,7 @@ import userImg from '@/assets/userImg.jpg';
 // mini, middle, large
 
 interface UserProfileProps {
-  type: 'board' | 'comment' | 'portfolio';
+  type: 'board' | 'comment' | 'portfolio' | 'blackboard';
   username: string;
   date?: string;
 }
@@ -23,21 +23,34 @@ const ImageSizes: any = {
   board: 65,
   comment: 35,
   portfolio: 100,
+  blackboard: 65
 }
 
 const UserProfile = ({ type, username, date }: UserProfileProps) => {
   return (
     <FlexWrapper gap={15} className='items-center'>
       <Image url={userImg} shape='circle' size={ImageSizes[type]} />
-      {type === 'board' ?
-        <FlexColumnWrapper gap={0}>
-          <Label text={username} type={type} />
-          <span>{date}2022.06.30</span>
-        </FlexColumnWrapper>
-        :
-        <Label text={username} type={type} />
-      }
+      {(() => {
+        if (type === 'board') {
+          return (
+            <FlexColumnWrapper gap={0}>
+              <Label text={username} type={type} />
+              <span>{date}2022.06.30</span>
+            </FlexColumnWrapper>
+          );
+        } else if (type === 'blackboard') {
+          return (
+            <FlexColumnWrapper gap={0}>
+              <Label text={username} type={type} />
+              <span className="text-zinc-200">{date}2022.06.30</span>
+            </FlexColumnWrapper>
+          );
+        } else {
+          return <Label text={username} type={type} />;
+        }
+      })()}
     </FlexWrapper >
+
   )
 }
 

--- a/client/src/commons/styles/Inputs.styled.tsx
+++ b/client/src/commons/styles/Inputs.styled.tsx
@@ -7,11 +7,11 @@ export const Input = styled.input`
 `;
 
 export const TextArea = styled.textarea`
-    ${tw`resize-none rounded-md border-[0.5px] `}
+    ${tw`resize-none rounded-md border-[0.5px] px-2 py-1`}
     &:focus {outline: none;}
     border-color: gray;
     font-size: 13px;
-    color:white;
+    color:black;
 `
 
 export const PortfolioTitleInput = styled(Input)`

--- a/client/src/components/detailContents/DetailContents.styled.tsx
+++ b/client/src/components/detailContents/DetailContents.styled.tsx
@@ -6,6 +6,7 @@ export const DetailCntContainer = styled.div`
     bg-white
     p-5
     shadow-md
+    mt-5
   `}
 
   height: 700px;

--- a/client/src/pages/community-add/AddCommunity.tsx
+++ b/client/src/pages/community-add/AddCommunity.tsx
@@ -9,7 +9,6 @@ import {
 import PurpleBtn from '@/commons/atoms/buttons/PurpleBtn';
 import 'react-quill/dist/quill.snow.css';
 import ReactQuill from 'react-quill';
-import { type } from './../../types/StyleType';
 import { useState, useRef } from 'react';
 
 export default function AddCommunity() {
@@ -40,7 +39,6 @@ export default function AddCommunity() {
 
   return (
     <>
-      {/* <CHeader /> */}
       <EditorContainer>
         <TextEditorContainer>
           <h1 className='addTitle'>Edit Your Forum</h1>

--- a/client/src/pages/community-detail/CommunityDetail.styled.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.styled.tsx
@@ -3,7 +3,7 @@ import { styled } from 'styled-components'
 import communitymainimg from '../../assets/communitymainimg.png';
 
 export const PageWrapper = styled.div(({ theme }) => [
-  tw`w-full h-full min-h-screen bg-center bg-no-repeat bg-cover `,
+  tw`w-full h-full min-h-screen bg-center bg-no-repeat bg-cover py-5`,
   { backgroundImage: `url(${communitymainimg})` },
 ]);
 

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -15,7 +15,7 @@ export default function CommunityDetail() {
     <PageWrapper>
       <MainContainer>
         <CmDContainer>
-          <UserProfile type={'board'} username={'emma'} />
+          <UserProfile type={'blackboard'} username={'emma'} />
           <DetailContents />
         </CmDContainer>
 

--- a/client/src/pages/community-main/CommunityMain.tsx
+++ b/client/src/pages/community-main/CommunityMain.tsx
@@ -9,8 +9,6 @@ import {
 } from './CommunityMain.styled';
 import CommunityItem from '@/components/communityItem/CommunityItem';
 import WritingBtn from '@/commons/atoms/buttons/writing/writingBtn';
-// import CHeader from '@/commons/atoms/header/CHeader';
-// import { BackImgControl } from '@/commons/styles/layout/Layout.styled';
 
 export default function CommunityMain() {
   return (
@@ -20,9 +18,11 @@ export default function CommunityMain() {
       </SearchContainer>
 
       <ItemWrapper>
-        <StyledWritingBtn>
+        <Link to="/boards/edit">
+          <StyledWritingBtn>
           <WritingBtn />
-        </StyledWritingBtn>
+          </StyledWritingBtn>
+        </Link>
         <ListsWrapper>
           {Array.from({ length: 8 }).map((_, index) => {
             return (

--- a/client/src/pages/mypage/MyPage.styled.tsx
+++ b/client/src/pages/mypage/MyPage.styled.tsx
@@ -2,7 +2,6 @@ import tw from 'twin.macro'
 import { styled } from 'styled-components'
 
 export const MainWrapper = tw.div`
-  bg-BASIC_BLACK
     w-screen
     h-full
     flex

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -1,6 +1,6 @@
 // type 모아두는 곳
 
-import { EventHandler } from "react";
+import { ButtonHTMLAttributes, DetailedHTMLProps, EventHandler } from "react";
 
 //하위 chilrdern string 인터페이스 + 0705 혜진 mypage 아이템
 export interface childrenProps {
@@ -15,4 +15,10 @@ export interface MypageItemProps extends childrenProps {
     src: string;
 }
 
+
+//0707 혜진 styled props 관련 type
+export interface Styledprops 
+    extends DetailedHTMLProps<ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement> {
+        color: string;
+}
 


### PR DESCRIPTION
# 개요 
UI 추합 작업 4차 입니다. 

# 작업 사항 
- 전반적인 UI 수정 
- 배경 이미지 헤더에 적용 ( 헤더 fix 아직 미 작업)
- 링크 연결 
   * CHeader 의 Recruitment와 Community 는 링크 작업 하지 않았습니다. 


# 특이 사항 
### UserProfile
해당 컴포넌트가 게시판 메인에서는  검정색 글씨, 게시판 상세 페이지에서는 하얗색 글씨가 적용되어야 했기에 type에 'blackboard' 를 추가하였고, if문으로 조건에 맞추어 알맞는 컴포넌트 구조를 반환합니다. 
```javascript

interface UserProfileProps {
  type: 'board' | 'comment' | 'portfolio' | 'blackboard';
  username: string;
  date?: string;
}

const ImageSizes: any = {
  board: 65,
  comment: 35,
  portfolio: 100,
  blackboard: 65
}

const UserProfile = ({ type, username, date }: UserProfileProps) => {
  return (
    <FlexWrapper gap={15} className='items-center'>
      <Image url={userImg} shape='circle' size={ImageSizes[type]} />
      {(() => {
        if (type === 'board') {
          return (
            <FlexColumnWrapper gap={0}>
              <Label text={username} type={type} />
              <span>{date}2022.06.30</span>
            </FlexColumnWrapper>
          );
        } else if (type === 'blackboard') {
          return (
            <FlexColumnWrapper gap={0}>
              <Label text={username} type={type} />
              <span className="text-zinc-200">{date}2022.06.30</span>
            </FlexColumnWrapper>
          );
        } else {
          return <Label text={username} type={type} />;
        }
      })()}
    </FlexWrapper >

  )
}
```

### 'blackboard type' 
- 'board' 타입과 동일하나 글자 색상만 white 입니다. 
![스크린샷 2023-07-07 오후 4 47 40](https://github.com/codestates-seb/seb44_main_013/assets/110151638/711adecc-a183-44d5-8524-ca730404b50a)

# 예시 스크린 샷
![스크린샷 2023-07-07 오후 4 43 59](https://github.com/codestates-seb/seb44_main_013/assets/110151638/08deba6c-292e-4ba9-9013-459aceb4c73e)
![스크린샷 2023-07-07 오후 4 43 51](https://github.com/codestates-seb/seb44_main_013/assets/110151638/0e83ec1d-a438-4698-990b-b710040e22b4)
