### PR TITLE
Fix: UserProfile이 들어가는 페이지에 임시 user props를 전달한다.

### DIFF
--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -15,7 +15,7 @@ export default function Comment({ username, content, date }: CommentProps) {
   return (
     <FlexColumnContainer gap={10} className='w-full border-b-[1px] pb-1.5 pt-3'>
       <FlexWrapper gap={0} className='w-full justify-between'>
-        <UserProfile type='comment' username={username} />
+        <UserProfile type='comment' user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
         <FlexWrapper gap={0}>
           <ReviseBtn color={'black'} />
           <RemoveBtn color={'black'} />

--- a/client/src/commons/molecules/CommentWriteBox.tsx
+++ b/client/src/commons/molecules/CommentWriteBox.tsx
@@ -5,13 +5,13 @@ import { TextArea } from '@/commons/styles/Inputs.styled';
 import SaveBtn from '../atoms/buttons/writing/SaveBtn';
 
 export default function CommentWriteBox() {
-    return (
-        <FlexColumnContainer gap={5} className='w-full bt-[1px] mt-10'>
-            <FlexWrapper gap={0} className='w-full justify-between'>
-                <UserProfile type='comment' username='ehyo' date='39-29-39' />
-                <SaveBtn />
-            </FlexWrapper>
-            <TextArea className="w-full h-20" placeholder="write your comment"/>
-        </FlexColumnContainer>
-    )
+  return (
+    <FlexColumnContainer gap={5} className='w-full bt-[1px] mt-10'>
+      <FlexWrapper gap={0} className='w-full justify-between'>
+        <UserProfile type='comment' user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
+        <SaveBtn />
+      </FlexWrapper>
+      <TextArea className="w-full h-20" placeholder="write your comment" />
+    </FlexColumnContainer>
+  )
 } 

--- a/client/src/components/communityItem/CommunityItem.tsx
+++ b/client/src/components/communityItem/CommunityItem.tsx
@@ -5,7 +5,7 @@ import UserProfile from '@/commons/molecules/UserProfile';
 export default function CommunityItem() {
   return (
     <CommunityItemContainer>
-      <UserProfile type={'board'} username={'emma'} />
+      <UserProfile type={'board'} user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
       <h2>Title</h2>
       <p>contents</p>
       <Views />

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -11,7 +11,7 @@ import CommentBox from '@/components/CommentBox';
 export default function CommunityDetail() {
   return (
     <PageWrapper>
-      <UserProfile type={'blackboard'} username={'emma'} />
+      <UserProfile type={'blackboard'} user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
       <MainContainer>
         <CmDContainer>
           <DetailContents />

--- a/client/src/pages/portfolio-detail/PortfolioDetail.tsx
+++ b/client/src/pages/portfolio-detail/PortfolioDetail.tsx
@@ -34,7 +34,7 @@ export default function PortfolioDetail() {
         <UserContainer>
           <UserCard>
             <FlexWrapper gap={0} className='justify-between'>
-              <LikeBtn />
+              <LikeBtn likes={isSuccess && data.likes} />
               <Bookmark />
             </FlexWrapper>
             <UserProfile type="portfolio" username="HOHO" />


### PR DESCRIPTION
# 작업내용
* UserProfile 컴포넌트 props가 변했기 때문에 UserProfile이 포함된 페이지마다 수정을 해주었습니다.
* 임시 user객체를 보냈습니다. 그래서 이미지도 안 뜰 거예요. 나중에 msw로 가짜 데이터 넣으실 때 picture 칼럼에 이미지 url 넣으신 뒤 GET 요청하면 잘 받아집니다.
* 제가 빠트린 부분이 있다면 UserProfile 컴포넌트가 포함된 해당 페이지가 아예 안 나올 수 있습니다. 유저프로필 props 때문이니 user 객체를 인자로 전달해주세요.