### PR TITLE
Feat: 게시판 메인 페이지 목록 조회 기능 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,7 +29,7 @@ const App = () => {
 
           <Route element={<CHeaderLayout />}>
             <Route path="/boards" element={<CommunityMain />} />
-            <Route path="/boards/detail" element={<CommunityDetail/>}/>
+            <Route path="/boards/detail/:member_Id" element={<CommunityDetail/>}/>
             <Route path="/boards/edit" element={<AddCommunity/>}/>
           </Route>
 

--- a/client/src/components/communityItem/CommunityItem.tsx
+++ b/client/src/components/communityItem/CommunityItem.tsx
@@ -2,13 +2,15 @@ import { CommunityItemContainer } from './CommunityItem.styled';
 import Views from '../views/Views';
 import UserProfile from '@/commons/molecules/UserProfile';
 
-export default function CommunityItem() {
+export default function CommunityItem(datas: any) {
+  const eachData = datas.datas
+
   return (
     <CommunityItemContainer>
-      <UserProfile type={'board'} user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
-      <h2>Title</h2>
-      <p>contents</p>
-      <Views />
+      <UserProfile type={'board'} user={{ member_id: eachData.member_id, name: eachData.name, picture: 'https://picsum.photos/200/300' }} />
+      <h2>{eachData.title}</h2>
+      <p>{eachData.content}</p>
+      <Views view={eachData.view}/>
     </CommunityItemContainer>
   );
 }

--- a/client/src/components/views/Views.tsx
+++ b/client/src/components/views/Views.tsx
@@ -1,7 +1,7 @@
 import { ViewContainer } from "./Views.styled"
 
-export default function Views () {
+export default function Views ({view}:any) {
   return (
-    <ViewContainer>View 2,000</ViewContainer>
+    <ViewContainer>View {view}</ViewContainer>
   )
-};
+}

--- a/client/src/pages/community-main/CommunityMain.tsx
+++ b/client/src/pages/community-main/CommunityMain.tsx
@@ -1,5 +1,7 @@
 import { Link } from 'react-router-dom';
+import { useState, useEffect } from 'react';
 import Search from '@/components/search/Search';
+import { call } from '@/utils/ApiService';
 import {
   ItemWrapper,
   SearchContainer,
@@ -10,7 +12,23 @@ import {
 import CommunityItem from '@/components/communityItem/CommunityItem';
 import WritingBtn from '@/commons/atoms/buttons/writing/writingBtn';
 
+import { CommuProps } from '@/types';
+
 export default function CommunityMain() {
+  const [ datas, setDatas ] = useState<CommuProps[]>([])
+
+  useEffect(() => {
+    const axiosCommu = async () => {
+      return call('/boards', 'GET', null)
+      .then((res) => {
+        setDatas(res);
+      })
+      .catch((err) => console.log('게시판 목록 조회 에러입니다. ' + err));
+    }
+
+    axiosCommu();
+  }, []);
+
   return (
     <CommunityWrapper>
       <SearchContainer>
@@ -24,13 +42,13 @@ export default function CommunityMain() {
           </StyledWritingBtn>
         </Link>
         <ListsWrapper>
-          {Array.from({ length: 8 }).map((_, index) => {
-            return (
-              <Link to="/boards/detail">
-                <CommunityItem key={index} />
-              </Link>
-            );
-          })}
+          {
+            datas.map((e) => {
+              return(
+                <CommunityItem key={e.board_id} datas={e} />
+              )
+            })
+          }
         </ListsWrapper>
       </ItemWrapper>
     </CommunityWrapper>


### PR DESCRIPTION
# 개요 
게시판 메인 페이지 목록 조회 기능 구현 PR 입니다. 

# 작업사항 
- Communit-main page 에서 전체 게시판 목록 조회를 위해 GET 요청 코드 작성 
- msw 사용해서 더미 데이터로 코드 테스트 완료
   **특이사항**
       - 현재는 기업 공고와 파트너 게시판 구분하지 않음.

# 스크린 샷 
![스크린샷 2023-07-10 오후 4 55 21](https://github.com/codestates-seb/seb44_main_013/assets/110151638/77086673-e789-4cd9-b31c-d6cd78825e80)


