### PR TITLE
Feat: 게시판 상세 페이지 조회 기능 구현

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -29,7 +29,7 @@ const App = () => {
 
           <Route element={<CHeaderLayout />}>
             <Route path="/boards" element={<CommunityMain />} />
-            <Route path="/boards/detail/:member_Id" element={<CommunityDetail/>}/>
+            <Route path="/boards/:board_id" element={<CommunityDetail/>}/>
             <Route path="/boards/edit" element={<AddCommunity/>}/>
           </Route>
 

--- a/client/src/commons/atoms/Card.tsx
+++ b/client/src/commons/atoms/Card.tsx
@@ -8,7 +8,7 @@ interface CardProps extends ComponentPropsWithoutRef<'div'> {
 }
 
 const CardContainer = styled.div`
-    ${tw`flex flex-col w-full h-full p-5 box-border rounded-2xl`}
+    ${tw`flex flex-col w-full h-[700px] p-5 box-border rounded-2xl justify-between`}
 
     background-color: white;
     box-sizing: inherit;

--- a/client/src/commons/atoms/buttons/writing/SaveBtn.tsx
+++ b/client/src/commons/atoms/buttons/writing/SaveBtn.tsx
@@ -1,5 +1,9 @@
 import { Edittype } from "../Button.styled"
 
-export default function SaveBtn(){
-    return <Edittype>Save</Edittype>
+interface IProps {
+    onClick: () => void;
+}
+
+export default function SaveBtn( {onClick}:IProps ){
+    return <Edittype onClick={onClick}>Save</Edittype>
 }

--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -4,18 +4,27 @@ import UserProfile from './UserProfile';
 import ReviseBtn from '../atoms/buttons/revise-remove/ReviseBtn';
 import RemoveBtn from '../atoms/buttons/revise-remove/RemoveBtn';
 import { BodyText, SmallText } from '../atoms/Typography';
+import { CommentProps } from '@/types';
 
-interface CommentProps {
+interface CommuCommentProps {
   username: string;
   content: string;
   date: string;
+  comment: CommentProps;
 }
 
-export default function Comment({ username, content, date }: CommentProps) {
+export default function Comment({ username, content, date, comment }: CommuCommentProps) {
+  const nDate = new Date(date);
+  const convertDate = nDate.toLocaleDateString('en-US',{
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+  }).replace(/\//g, '.');
+
   return (
     <FlexColumnContainer gap={10} className='w-full border-b-[1px] pb-1.5 pt-3'>
       <FlexWrapper gap={0} className='w-full justify-between'>
-        <UserProfile type='comment' user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
+        <UserProfile type='comment' user={{ member_id: comment.member_id, name: username, picture: 'https://picsum.photos/200/300' }} />
         <FlexWrapper gap={0}>
           <ReviseBtn color={'black'} />
           <RemoveBtn color={'black'} />
@@ -23,7 +32,7 @@ export default function Comment({ username, content, date }: CommentProps) {
       </FlexWrapper>
       <FlexWrapper gap={0} className='w-full justify-between'>
         <BodyText>{content}</BodyText>
-        <SmallText color='gray'>{date}</SmallText>
+        <SmallText color='gray'>{convertDate}</SmallText>
       </FlexWrapper>
     </FlexColumnContainer>
   )

--- a/client/src/commons/molecules/CommentWriteBox.tsx
+++ b/client/src/commons/molecules/CommentWriteBox.tsx
@@ -4,14 +4,20 @@ import UserProfile from './UserProfile';
 import { TextArea } from '@/commons/styles/Inputs.styled';
 import SaveBtn from '../atoms/buttons/writing/SaveBtn';
 
-export default function CommentWriteBox() {
+
+export default function CommentWriteBox({saveComment, handleComment, isInput}:any) {
+
   return (
     <FlexColumnContainer gap={5} className='w-full bt-[1px] mt-10'>
       <FlexWrapper gap={0} className='w-full justify-between'>
-        <UserProfile type='comment' user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
-        <SaveBtn />
+        <UserProfile type='comment' user={{ member_id: 1, name: 'jhj', picture: 'https://picsum.photos/233'  }} />
+        <SaveBtn onClick={saveComment} />
       </FlexWrapper>
-      <TextArea className="w-full h-20" placeholder="write your comment" />
+      <TextArea className="w-full h-20" 
+        placeholder="write your comment" 
+        value={isInput}
+        onChange={(e:any) => handleComment(e.target.value)}
+      />
     </FlexColumnContainer>
   )
 } 

--- a/client/src/components/CommentBox.tsx
+++ b/client/src/components/CommentBox.tsx
@@ -3,19 +3,26 @@ import Card from '@/commons/atoms/Card';
 import Comment from '@/commons/molecules/Comment';
 import { FlexColumnContainer } from '@/commons/styles/Containers.styled';
 import CommentWriteBox from '@/commons/molecules/CommentWriteBox';
+import { CommentProps } from '@/types';
 
-interface CommentBoxProps {
-    comment: 'CommentType'
-}
 
-export default function CommentBox({ comment }: CommentBoxProps) {
+export default function CommentBox( {comment}:any) {
     return (
-        <Card className='justify-between'>
-            <FlexColumnContainer gap={0}>
-                <Comment username='vite' content='zzzzz' date='2020-20-20' />
-                <Comment username='vite' content='zzzzz' date='2020-20-20' />
+        <Card>
+            <FlexColumnContainer gap={0} className="overflow-scroll">
+                {
+                    comment.map((e:CommentProps) => {
+                        return (<Comment key={e.comments_id}
+                                        username={e.name}
+                                        content={e.content}
+                                        date={e.createdAt}
+                                        comment={e}
+                                />
+                        )
+                    })
+                }
             </FlexColumnContainer>
-            <CommentWriteBox />
+            <CommentWriteBox/>
         </Card>
     )
 } 

--- a/client/src/components/communityItem/CommunityItem.tsx
+++ b/client/src/components/communityItem/CommunityItem.tsx
@@ -1,12 +1,19 @@
 import { CommunityItemContainer } from './CommunityItem.styled';
 import Views from '../views/Views';
 import UserProfile from '@/commons/molecules/UserProfile';
+import { useNavigate } from 'react-router-dom';
+import { CommuProps } from '@/types';
 
 export default function CommunityItem(datas: any) {
+  const navigate = useNavigate();
   const eachData = datas.datas
 
+  const HandleClick= ( e:CommuProps ) => {
+    navigate(`/boards/${e.board_id}`, { state: e });
+  }
+
   return (
-    <CommunityItemContainer>
+    <CommunityItemContainer onClick={() => { HandleClick(eachData)}}>
       <UserProfile type={'board'} user={{ member_id: eachData.member_id, name: eachData.name, picture: 'https://picsum.photos/200/300' }} />
       <h2>{eachData.title}</h2>
       <p>{eachData.content}</p>

--- a/client/src/components/detailContents/DetailContents.tsx
+++ b/client/src/components/detailContents/DetailContents.tsx
@@ -1,12 +1,13 @@
 import PurpleBtn from '@/commons/atoms/buttons/PurpleBtn';
 import { DetailCntContainer, EDBtnContainer } from './DetailContents.styled';
 
-export default function DetailContents() {
+export default function DetailContents( {data}:any ) {
+
   return (
     <DetailCntContainer>
-      <h1>Title</h1>
+      <h1>{data.title}</h1>
       <hr />
-      <p>Contents</p>
+      <p>{data.content}</p>
       <hr />
       <EDBtnContainer>
         <PurpleBtn>Edit</PurpleBtn>

--- a/client/src/mocks/data.ts
+++ b/client/src/mocks/data.ts
@@ -14,3 +14,178 @@ export const portfolios = [
     tags: ['javascript', 'react', '집', '잠', '영화', '로또', '백수']
   },
 ]
+
+
+/*2023-07-10 Mypage User Information - 위정연 */
+export interface UserData {
+  job: string;
+  career: string;
+  awards: string;
+}
+
+export const userData: UserData = {
+  job: 'What is your job?',
+  career: 'Career 1',
+  awards: 'Awards 1',
+};
+
+//혜진 data
+import { CommuProps } from "@/types"
+
+export const commu: CommuProps[] = [
+  {
+    board_id: 1,
+    title: "박효정씨는 아침 요청입니다.",
+    content: "매일 아침마다 효정씨는 모두에게 아침 인사를 해줍니다. 아주 성실한 친구죠.",
+    view: 208,
+    division: "recruitment",
+    name: "phy",
+    created_at: "2023-06-21T17:34:51.3395597",
+    modifiedAt: "2023-06-21T17:34:51.3395597",
+    member_id: 1,
+    status: true
+  },
+  {
+    board_id: 2,
+    title: "위정연씨는 칭찬 스티커를 줍니다.",
+    content: "잘 하는 사람만 정연씨의 칭찬 스티커를 받을 수 있죠.",
+    view: 200,
+    division: "recruitment",
+    name: "yjy",
+    created_at: "2023-05-21T17:34:51.3395597",
+    modifiedAt: "2023-05-21T17:34:51.3395597",
+    member_id: 2,
+    status: true
+  },
+  {
+    board_id: 3,
+    title: "김다함씨는 열정맨입니다.",
+    content: "다함씨는 조용히 다함",
+    view: 150,
+    division: "recruitment",
+    name: "kdh",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    member_id: 3,
+    status: true
+  }
+
+];
+
+export const commuDetail = [
+  {
+    board_id: 1,
+    title: "박효정씨는 아침 요청입니다.",
+    content: "매일 아침마다 효정씨는 모두에게 아침 인사를 해줍니다. 아주 성실한 친구죠.",
+    division: "recruitment",
+    name: "phy",
+    created_at: "2023-06-21T17:34:51.3395597",
+    modifiedAt: "2023-06-21T17:34:51.3395597",
+    member_id: 1,
+    status: true,
+    comment: [
+      {
+        comments_id: 1,
+        content: '울랄랄 숑숑숑 댓글',
+        member_id: 1,
+        name:'phj',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 2,
+        content: '댓글2',
+        member_id: 2,
+        name:'wjw',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      }
+    ]
+    
+  },
+  {
+    board_id: 2,
+    title: "위정연씨는 칭찬 스티커를 줍니다.",
+    content: "잘 하는 사람만 정연씨의 칭찬 스티커를 받을 수 있죠.",
+    division: "recruitment",
+    name: "wjw",
+    created_at: "2023-06-21T17:34:51.3395597",
+    modifiedAt: "2023-06-21T17:34:51.3395597",
+    member_id: 1,
+    status: true,
+    comment: [
+      {
+        comments_id: 1,
+        content: '울랄랄 숑숑숑 댓글',
+        member_id: 1,
+        name:'phj',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 2,
+        content: '댓글2',
+        member_id: 2,
+        name:'wjw',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 3,
+        content: '댓글3',
+        member_id: 3,
+        name:'kdh',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 4,
+        content: '댓글4',
+        member_id: 1,
+        name:'phj',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      }
+    ]
+    
+  }, 
+  {
+    board_id: 3,
+    title: "김다함씨는 열정맨입니다.",
+    content: "다함씨는 조용히 다함",
+    division: "recruitment",
+    name: "kdh",
+    created_at: "2023-06-21T17:34:51.3395597",
+    modifiedAt: "2023-06-21T17:34:51.3395597",
+    member_id: 1,
+    status: true,
+    comment: [
+      {
+        comments_id: 1,
+        content: '울랄랄 숑숑숑 댓글',
+        member_id: 1,
+        name:'phj',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 2,
+        content: '댓글2',
+        member_id: 2,
+        name:'wjw',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 3,
+        content: '댓글3',
+        member_id: 3,
+        name:'kdh',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      },{
+        comments_id: 4,
+        content: '댓글4',
+        member_id: 1,
+        name:'phj',
+        createdAt: "2023-06-23T17:34:51.3395597",
+        modifiedAt: "2023-06-23T17:34:51.3395597"
+      }
+    ]
+    
+  }
+];

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -1,6 +1,6 @@
 // src/mocks/handlers.js
 import { rest } from 'msw';
-import { portfolios } from './data';
+import { portfolios, commu, commuDetail } from './data';
 
 const DaHamHandlers = [
   rest.get('/portfolios/:portfolio_id', (req, res, ctx) => {
@@ -10,4 +10,72 @@ const DaHamHandlers = [
   })
 ];
 
-export const handlers = DaHamHandlers;
+
+
+
+
+/**0710 정연 Mypage 사용자 정보 수정 */
+// mocks/handlers.ts
+import { UserData, userData } from './data';
+
+const UserHandlers = [
+  rest.put<UserData>('/members', (req, res, ctx) => {
+    Object.assign(userData, req.body);
+
+    return res(ctx.json(userData));
+  }),
+  rest.get<UserData>('/members', (req, res, ctx) => {
+    return res(ctx.json(userData));
+  }),
+];
+
+
+
+//혜진 게시판 파트 
+const HJHandlers = [
+  //1. 게시판 목록 조회 GET : community-main page
+  rest.get('/boards', (_, res, ctx) => {
+    return res(ctx.status(200), ctx.json(commu));
+  }),
+  //2. 게시한 상세 페이지 조회 GET : community-detail page
+  rest.get('/boards/:board_id', (req, res, ctx) => {
+    const board_id = Number(req.params.board_id);
+    const filteredData = commuDetail.filter(e => e.board_id === board_id);
+    return (res(ctx.status(200), ctx.json(filteredData)))
+  }),
+  //3. 댓글 수정
+
+
+  //4. 댓글 작성 
+  rest.post('/comments', async(req, res, ctx) => {
+    const board_id = 2;
+  
+    const filteredData = commuDetail.find(e => e.board_id === board_id); 
+    if(!filteredData){
+      return res(ctx.status(404), ctx.json({message: '게시물을 찾을 수 없다.'}));
+    }
+    const comments_id  = filteredData.comment.length || 0;
+  
+    const newPostData = {
+      comments_id: comments_id+1,
+      content: (await req.json()).content,
+      member_id: 1,
+      name: 'jhj',
+      createdAt: "2023-06-21T17:34:51.3395597",
+      modifiedAt:"2023-06-21T17:34:51.3395597"
+    }
+    //filteredData.comment.push(newPostData);
+    const index = commuDetail.findIndex(e => e.board_id === board_id);
+    if(index !== -1){
+      commuDetail[index].comment.push(newPostData);
+    }
+    console.log(commuDetail[1].comment);
+    return res(ctx.status(200), ctx.json(newPostData));
+  }),
+];
+
+
+
+export const handlers = DaHamHandlers
+  .concat(UserHandlers)
+  .concat(HJHandlers);

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -69,7 +69,7 @@ const HJHandlers = [
     if(index !== -1){
       commuDetail[index].comment.push(newPostData);
     }
-    console.log(commuDetail[1].comment);
+    //console.log(commuDetail[1].comment);
     return res(ctx.status(200), ctx.json(newPostData));
   }),
 ];

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -1,3 +1,7 @@
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+import { call } from '@/utils/ApiService';
+
 import UserProfile from '@/commons/molecules/UserProfile';
 import DetailContents from '@/components/detailContents/DetailContents';
 import {
@@ -6,20 +10,46 @@ import {
   MainContainer,
   PageWrapper,
 } from './CommunityDetail.styled';
+import Loading from '../404/Loading';
 import CommentBox from '@/components/CommentBox';
+import { CommuProps } from '@/types';
 
-export default function CommunityDetail() {
+export default function CommunityDetail( {handleClick}:any ) {
+  const [ memberData, setMemberData ] = useState<CommuProps>();
+  const { board_id } = useParams();
+
+  useEffect(()=> {
+    const axiosMember = async () => {
+      return call(`/boards/${board_id}`, 'GET', null)
+      .then((res) => {
+        setMemberData(res[0]);
+      })
+      .catch((err) => console.log('커뮤니티 상세 페이지 예시' + err)); 
+    };
+
+    axiosMember();
+  }, [board_id]);
+
   return (
-    <PageWrapper>
-      <UserProfile type={'blackboard'} user={{ member_id: 1, name: 'dsf', picture: 'asdf' }} />
-      <MainContainer>
-        <CmDContainer>
-          <DetailContents />
-        </CmDContainer>
-        <CommentContainer>
-          <CommentBox comment='CommentType' />
-        </CommentContainer>
-      </MainContainer>
+    <PageWrapper >
+      { memberData !== undefined ? 
+      ( <>
+          <UserProfile type={'blackboard'} 
+            user={{ member_id: memberData.member_id, 
+                    name: memberData.name, 
+                    picture: 'https://picsum.photos/200/300' 
+                  }} 
+          />
+          <MainContainer onClick={handleClick}>
+            <CmDContainer>
+              <DetailContents data={memberData}/>
+            </CmDContainer>
+            <CommentContainer>
+              <CommentBox comment={memberData.comment} />
+            </CommentContainer>
+          </MainContainer>
+        </>
+      ) : <><Loading/></>}
     </PageWrapper>
   );
 }

--- a/client/src/pages/community-main/CommunityMain.tsx
+++ b/client/src/pages/community-main/CommunityMain.tsx
@@ -17,6 +17,8 @@ import { CommuProps } from '@/types';
 export default function CommunityMain() {
   const [ datas, setDatas ] = useState<CommuProps[]>([])
 
+
+
   useEffect(() => {
     const axiosCommu = async () => {
       return call('/boards', 'GET', null)

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -23,3 +23,27 @@ export interface Styledprops
   color: string;
 }
 
+//0707 혜진 community-main:<data> commu
+export interface CommuProps {
+  board_id: number,
+  title: string,
+  content: string,
+  view: number,
+  division:string,
+  name: string,
+  created_at: string,
+  modifiedAt: string,
+  member_id: number,
+  status:boolean,
+  comment?: CommentProps[]
+}
+
+//0708 혜진 community-detail comments add
+export interface CommentProps {
+  comments_id: number;
+  content: string;
+  member_id: number;
+  name: string;
+  createdAt: string;
+  modifiedAt: string;
+}


### PR DESCRIPTION
# 개요 
게시판 상세 페이지 조회 기능 구현 

# 작업 사항 
- 게시판 메인에서 원하는 게시판 클릭 시 해당하는 게시판 상세 페이지로 이동 되며 관련된 댓글들도 조회 됩니다. 
- 댓글 등록 기능 구현 완료 


# 스크린 샷 
![스크린샷 2023-07-11 오후 12 13 04](https://github.com/codestates-seb/seb44_main_013/assets/110151638/c620aada-e64e-4edf-ae35-04312e180cb6)
![스크린샷 2023-07-11 오후 7 31 57](https://github.com/codestates-seb/seb44_main_013/assets/110151638/4c214f2c-e666-4e1d-bd60-079cd2d232ad)


# 특이사항 
- Card 컴포넌트에서 댓글 등록 폼을 하단으로 위치 고정
- 댓글 폼을 왼쪽 Content 와 동일하게 h-700px로 고정

- 댓글 handler 에서 board_id를 불러올 수가 없어서 임의로 2로 지정해둔 상태입니다. 
    * 테스트 결과 전부 댓글 등록 기능 구현 되지만 handler에서는 2에서만 데이터가 추가 되는 것을 확인 할 수 있습니다. 
- 유저프로필은 추후 백엔드에서 api 로 사진 불러올 때 그때 추가 수정 예정입니다. 
- 댓글 등록 오늘 날짜도 수정 작업 예정입니다. 