### PR TITLE
Rename: 게시판 부분 APi 명세서에 따른 변수 이름 변경 및 주석 정리 

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -31,7 +31,7 @@ const App = () => {
             </Route>
           <Route element={<CHeaderLayout />}>
             <Route path="/boards" element={<CommunityMain />} />
-            <Route path="/boards/:board_id" element={<CommunityDetail />} />
+            <Route path="/boards/:id" element={<CommunityDetail />} />
             <Route path="/boards/edit" element={<AddCommunity />} />
           </Route>
             <Route path="/portfolios/:portfolio_id" element={<PortfolioDetail />} />

--- a/client/src/commons/molecules/Comment.tsx
+++ b/client/src/commons/molecules/Comment.tsx
@@ -55,16 +55,8 @@ export default function Comment(
   };
 
   const handleChangeEditMode = () => {
-    // setIsEditMode((previousIsEditMode) => !previousIsEditMode);
-    //더블 클릭의 경우를 생각해주어야 합니다. 
-    // callback으로 -> react에서 맨 마지막 껄로 치환
     setIsEditMode(!isEditMode)
   };
-
-  // const editComment = () =>  {
-  //   handleClick();
-  // };
-
 
   useEffect(() => {
     //

--- a/client/src/components/CommentBox.tsx
+++ b/client/src/components/CommentBox.tsx
@@ -1,7 +1,6 @@
 /* 2023-07-05 게시물 상세보기 페이지 댓글 영역 컴포넌트 - 김다함 */
 import { useParams } from 'react-router-dom';
 import { useEffect, useState } from 'react';
-import axios from 'axios';
 
 import Card from '@/commons/atoms/Card';
 import Comment from '@/commons/molecules/Comment';
@@ -15,23 +14,19 @@ import { FlexColumnContainer } from '@/commons/styles/Containers.styled';
 import { call } from '@/utils/ApiService';
 
 
-export default function CommentBox( {comments = [] }:any) { // comment => comments
+export default function CommentBox( {comments = [] }:any) { 
     const [ currentComment, setCurrentComment ] = useState('');
-    //is로 시작하면 boolean으로 생각할 수도 있다. (isInput -> currentComment)
-    //Fn+f2
     const [ amendComment, setAmendComment ] = useState(comments);
     const [ deleteId, setDeleteId ] = useState(null);
-    const { board_id:boardId } = useParams(); //수정
+    const { id:boardId } = useParams(); 
     
     const handleComment = ( value: string ) => {
         setCurrentComment(value);
     }
 
-    //return문이 없고 async 체크 필요 -> await으로 받는 부분이 없음. (0712)
-    //async - await 
     const saveComment = () => {
         const addNewComment = () => call(`/comments`, 'POST', {
-            boardId: boardId,
+            id: boardId,
             content: currentComment,
         });
         const axiosPost = async () => {
@@ -52,30 +47,25 @@ export default function CommentBox( {comments = [] }:any) { // comment => commen
             status: "POST_ACTIVE"
         });
         setCurrentComment('');
-        // console.log(comments);
-        // console.log(amendComment);
     };
 
     useEffect(() => {
-        //약자는 최대한 쓰지 말자.
+
         const index = amendComment.findIndex((element:any) => element.comments_id === deleteId);
 
         // 첫번째 댓글 지울 때 
         if( index === 0 ){ // 수정합시당 : 과제 
             setAmendComment(amendComment.slice(1, amendComment.length));
         }
-        // 둘이 겹침 
+
         if( index > 0 ) {
             setAmendComment(amendComment.slice(0, index).concat(amendComment.slice(index+1, amendComment.length)));
         }
 
-        // else if 쓰지말장. - 현직자들이 싫어한당
         setDeleteId(null);
-        // console.log(newComment);
-        // -1 는 직독이해가 되지 않는다. 명시적 data 사용 ex. null
+
     }, [deleteId])
 
-    // console.log(amendComment)
 
     return (
         <Card>

--- a/client/src/components/communityItem/CommunityItem.tsx
+++ b/client/src/components/communityItem/CommunityItem.tsx
@@ -1,20 +1,25 @@
+import { useNavigate } from 'react-router-dom';
+
+import { CommuProps } from '@/types';
+
 import { CommunityItemContainer } from './CommunityItem.styled';
+
 import Views from '../views/Views';
 import UserProfile from '@/commons/molecules/UserProfile';
-import { useNavigate } from 'react-router-dom';
-import { CommuProps } from '@/types';
+
 
 export default function CommunityItem(datas: any) {
   const navigate = useNavigate();
   const eachData = datas.datas
 
-  const HandleClick = (e: CommuProps) => {
-    navigate(`/boards/${e.board_id}`, { state: e });
+  const handleLink = (e: CommuProps) => {
+    navigate(`/boards/${e.id}`, { state: e });
+    console.log(e.id);
   }
 
   return (
-    <CommunityItemContainer onClick={() => { HandleClick(eachData) }}>
-      <UserProfile type={'board'} user={{ member_id: eachData.member_id, name: eachData.name, picture: 'https://picsum.photos/200/300' }} />
+    <CommunityItemContainer onClick={() => { handleLink(eachData) }}>
+      <UserProfile type={'board'} user={{ member_id: eachData.memberId, name: eachData.name, picture: 'https://picsum.photos/200/300' }} />
       <h2>{eachData.title}</h2>
       <p>{eachData.content}</p>
       <Views view={eachData.view} />

--- a/client/src/mocks/data.ts
+++ b/client/src/mocks/data.ts
@@ -79,53 +79,10 @@ export const userData: UserData = {
 
 
 //혜진 data
-import { CommuProps } from "@/types"
-
-export const commu: CommuProps[] = [
-  {
-    board_id: 1,
-    //유저 프로필 이미지
-    title: "박효정씨는 아침 요청입니다.",
-    content: "매일 아침마다 효정씨는 모두에게 아침 인사를 해줍니다. 아주 성실한 친구죠.",
-    view: 208,
-    division: "RECRUITMENT",
-    name: "phy",
-    created_at: "2023-06-21T17:34:51.3395597",
-    modifiedAt: "2023-06-21T17:34:51.3395597",
-    member_id: 1,
-    status: "POST_ACTIVE"
-  },
-  {
-    board_id: 2,
-    //유저 프로필 이미지
-    title: "위정연씨는 칭찬 스티커를 줍니다.",
-    content: "잘 하는 사람만 정연씨의 칭찬 스티커를 받을 수 있죠.",
-    view: 200,
-    division: "COOPERATION",
-    name: "yjy",
-    created_at: "2023-05-21T17:34:51.3395597",
-    modifiedAt: "2023-05-21T17:34:51.3395597",
-    member_id: 2,
-    status: "POST_ACTIVE"
-  },
-  {
-    board_id: 3,
-    //유저 프로필 이미지
-    title: "김다함씨는 열정맨입니다.",
-    content: "다함씨는 조용히 다함",
-    view: 150,
-    division: "COOPERATION",
-    name: "kdh",
-    created_at: "2023-04-21T17:34:51.3395597",
-    modifiedAt: "2023-04-21T17:34:51.3395597",
-    member_id: 3,
-    status: "POST_ACTIVE"
-  }
-];
-
+//1,2,3만 상세 페이지 이동 가능 합니다. 
 export const commuDetail = [
   {
-    board_id: 1,
+    id: 1,
     title: "박효정씨는 아침 요청입니다.",
     content: "매일 아침마다 효정씨는 모두에게 아침 인사를 해줍니다. 아주 성실한 친구죠.",
     division: "RECRUITMENT",
@@ -133,13 +90,13 @@ export const commuDetail = [
     name: "phy",
     created_at: "2023-06-21T17:34:51.3395597",
     modifiedAt: "2023-06-21T17:34:51.3395597",
-    member_id: 1,
+    memberId: 1,
     status: "POST_ACTIVE", 
     comments: [
       {
         comments_id: 1,
         content: '울랄랄 숑숑숑 댓글',
-        member_id: 1,
+        memberId: 1,
         name: 'phj',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -147,7 +104,7 @@ export const commuDetail = [
       },{
         comments_id: 2,
         content: '댓글2',
-        member_id: 2,
+        memberId: 2,
         name: 'wjw',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -157,7 +114,7 @@ export const commuDetail = [
 
   },
   {
-    board_id: 2,
+    id: 2,
     //유저 프로필 
     title: "위정연씨는 칭찬 스티커를 줍니다.",
     content: "잘 하는 사람만 정연씨의 칭찬 스티커를 받을 수 있죠.",
@@ -166,14 +123,14 @@ export const commuDetail = [
     name: "wjw",
     created_at: "2023-06-21T17:34:51.3395597",
     modifiedAt: "2023-06-21T17:34:51.3395597",
-    member_id: 1,
+    memberId: 1,
     status: "POST_ACTIVE",
     comments: [
       {
         comments_id: 1,
         //유저 프로필 
         content: '울랄랄 숑숑숑 댓글',
-        member_id: 1,
+        memberId: 1,
         name: 'phj',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -182,7 +139,7 @@ export const commuDetail = [
         comments_id: 2,
         //유저 프로필 
         content: '댓글2',
-        member_id: 2,
+        memberId: 2,
         name: 'wjw',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597"
@@ -190,7 +147,7 @@ export const commuDetail = [
         comments_id: 3,
         //유저 프로필 
         content: '댓글3',
-        member_id: 3,
+        memberId: 3,
         name: 'kdh',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -199,7 +156,7 @@ export const commuDetail = [
         comments_id: 4,
         //유저 프로필 
         content: '댓글4',
-        member_id: 1,
+        memberId: 1,
         name: 'phj',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -209,7 +166,7 @@ export const commuDetail = [
 
   },
   {
-    board_id: 3,
+    id: 3,
     //유저 프로필 
     title: "김다함씨는 열정맨입니다.",
     content: "다함씨는 조용히 다함",
@@ -218,14 +175,14 @@ export const commuDetail = [
     name: "kdh",
     created_at: "2023-06-21T17:34:51.3395597",
     modifiedAt: "2023-06-21T17:34:51.3395597",
-    member_id: 1,
+    memberId: 1,
     status: "POST_ACTIVE",
     comments: [
       {
         comments_id: 1,
         //유저 프로필 
         content: '울랄랄 숑숑숑 댓글',
-        member_id: 1,
+        memberId: 1,
         name: 'phj',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -234,7 +191,7 @@ export const commuDetail = [
         comments_id: 2,
         //유저 프로필 
         content: '댓글2',
-        member_id: 2,
+        memberId: 2,
         name: 'wjw',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -243,7 +200,7 @@ export const commuDetail = [
         comments_id: 3,
         //유저 프로필 
         content: '댓글3',
-        member_id: 3,
+        memberId: 3,
         name: 'kdh',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -252,7 +209,7 @@ export const commuDetail = [
         comments_id: 4,
         //유저 프로필 
         content: '댓글4',
-        member_id: 1,
+        memberId: 1,
         name: 'phj',
         createdAt: "2023-06-23T17:34:51.3395597",
         modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -262,16 +219,4 @@ export const commuDetail = [
 
   }
 ];
-
-
-export const WholeData = [
-
-  {
-    data: {
-      member_id:1,
-      portfolio_id: 1,
-      title: "제목"
-    }
-  }
-]
 

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -1,6 +1,7 @@
 // src/mocks/handlers.js
 import { rest } from 'msw';
-import { portfolios, commu, commuDetail, UserData, userData, category, PortfolioType } from './data';
+import { portfolios, commuDetail, UserData, userData, category, PortfolioType } from './data';
+import { commu } from './infiniteScrollData'
 
 
 const DaHamHandlers = [
@@ -121,21 +122,21 @@ const HJHandlers = [
     return res(ctx.status(200), ctx.json(commu));
   }),
   //2. 게시한 상세 페이지 조회 GET : community-detail page
-  rest.get('/boards/:board_id', (req, res, ctx) => {
-    const board_id = Number(req.params.board_id);
-    const filteredData = commuDetail.filter(e => e.board_id === board_id);
+  rest.get('/boards/:id', (req, res, ctx) => {
+    const id = Number(req.params.id);
+    const filteredData = commuDetail.filter(e => e.id === id);
     return (res(ctx.status(200), ctx.json(filteredData)))
   }),
   //3. 댓글 수정
   rest.patch(`/comments/:comments_id`, async(req, res, ctx) => {
-    const { comments_id, member_id, content, name } = await req.json();
-    const filterdData = commuDetail.filter(el => el.board_id === 2);
+    const { comments_id, memberId, content, name } = await req.json();
+    const filterdData = commuDetail.filter(el => el.id === 2);
     const index = (filterdData[0].comments).findIndex(el => el.comments_id === comments_id);  
 
     const temp = {
       comments_id: comments_id,
       content: content,
-      member_id: member_id,
+      memberId: memberId,
       name: name,
       createdAt: "2023-06-23T17:34:51.3395597",
       modifiedAt: "2023-06-23T17:34:51.3395597",
@@ -156,7 +157,7 @@ const HJHandlers = [
   rest.post('/comments', async (req, res, ctx) => {
     const board_id = 2;
     // const {  board_id } = await req.json();
-    const filteredData = commuDetail.find(e => e.board_id === board_id);
+    const filteredData = commuDetail.find(e => e.id === board_id);
     if (!filteredData) {
       return res(ctx.status(404), ctx.json({ message: '게시물을 찾을 수 없다.' }));
     }
@@ -165,13 +166,13 @@ const HJHandlers = [
     const newPostData = {
       comments_id: comments_id + 1,
       content: (await req.json()).content,
-      member_id: 1,
+      memberId: 1,
       name: 'jhj',
       createdAt: "2023-06-21T17:34:51.3395597",
       modifiedAt: "2023-06-21T17:34:51.3395597"
     }
     //filteredData.comment.push(newPostData);
-    const index = commuDetail.findIndex(e => e.board_id === board_id);
+    const index = commuDetail.findIndex(e => e.id === board_id);
     if(index !== -1){
       commuDetail[index].comments.push(newPostData);
     }
@@ -181,7 +182,7 @@ const HJHandlers = [
   //5. 댓글 삭제
   rest.delete('/comments/:comments_id', async(req, res, ctx) => {
     const { comments_id } = await req.json();
-    const filterdData = commuDetail.filter(el => el.board_id === 2);
+    const filterdData = commuDetail.filter(el => el.id === 2);
     const index = (filterdData[0].comments).findIndex(el => el.comments_id === comments_id);  
     const newArr = (filterdData[0].comments).slice(0, index).concat((filterdData[0].comments).slice(index+1, -1))
 

--- a/client/src/mocks/infiniteScrollData.ts
+++ b/client/src/mocks/infiniteScrollData.ts
@@ -53,6 +53,421 @@ export const commu: CommuProps[] = [
     modifiedAt: "2023-04-21T17:34:51.3395597",
     memberId: 4,
     status: "POST_ACTIVE"
+  },
+  {
+    id: 5,
+    //유저 프로필 이미지
+    title: "테스트5",
+    content: "테스트 컨탠트5",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 5,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 6,
+    //유저 프로필 이미지
+    title: "테스트6",
+    content: "테스트 컨탠트4",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 6,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 7,
+    //유저 프로필 이미지
+    title: "테스트7",
+    content: "테스트 컨탠트4",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 7,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 8,
+    //유저 프로필 이미지
+    title: "테스트8",
+    content: "테스트 컨탠트8",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 8,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 9,
+    //유저 프로필 이미지
+    title: "테스트9",
+    content: "테스트 컨탠트9",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 9,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 10,
+    //유저 프로필 이미지
+    title: "테스트10",
+    content: "테스트 컨탠트10",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 10,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 11,
+    //유저 프로필 이미지
+    title: "테스트11",
+    content: "테스트 컨탠트11",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 11,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 12,
+    //유저 프로필 이미지
+    title: "테스트12",
+    content: "테스트 컨탠트12",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 13,
+    //유저 프로필 이미지
+    title: "테스트13",
+    content: "테스트 컨탠트13",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 14,
+    //유저 프로필 이미지
+    title: "테스트14",
+    content: "테스트 컨탠트14",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 15,
+    //유저 프로필 이미지
+    title: "테스트15",
+    content: "테스트 컨탠트15",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 16,
+    //유저 프로필 이미지
+    title: "테스트16",
+    content: "테스트 컨탠트16",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 17,
+    //유저 프로필 이미지
+    title: "테스트17",
+    content: "테스트 컨탠트17",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 18,
+    //유저 프로필 이미지
+    title: "테스트18",
+    content: "테스트 컨탠트18",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 19,
+    //유저 프로필 이미지
+    title: "테스트19",
+    content: "테스트 컨탠트19",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 20,
+    //유저 프로필 이미지
+    title: "테스트20",
+    content: "테스트 컨탠트20",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 21,
+    //유저 프로필 이미지
+    title: "테스트21",
+    content: "테스트 컨탠트21",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 22,
+    //유저 프로필 이미지
+    title: "테스트22",
+    content: "테스트 컨탠트22",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 23,
+    //유저 프로필 이미지
+    title: "테스트23",
+    content: "테스트 컨탠트23",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 24,
+    //유저 프로필 이미지
+    title: "테스트24",
+    content: "테스트 컨탠트24",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 25,
+    //유저 프로필 이미지
+    title: "테스트25",
+    content: "테스트 컨탠트25",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 26,
+    //유저 프로필 이미지
+    title: "테스트26",
+    content: "테스트 컨탠트26",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 27,
+    //유저 프로필 이미지
+    title: "테스트27",
+    content: "테스트 컨탠트27",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 28,
+    //유저 프로필 이미지
+    title: "테스트28",
+    content: "테스트 컨탠트28",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 29,
+    //유저 프로필 이미지
+    title: "테스트29",
+    content: "테스트 컨탠트29",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 30,
+    //유저 프로필 이미지
+    title: "테스트30",
+    content: "테스트 컨탠트30",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 31,
+    //유저 프로필 이미지
+    title: "테스트31",
+    content: "테스트 컨탠트31",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 32,
+    //유저 프로필 이미지
+    title: "테스트32",
+    content: "테스트 컨탠트32",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 33,
+    //유저 프로필 이미지
+    title: "테스트33",
+    content: "테스트 컨탠트33",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 34,
+    //유저 프로필 이미지
+    title: "테스트34",
+    content: "테스트 컨탠트34",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 35,
+    //유저 프로필 이미지
+    title: "테스트35",
+    content: "테스트 컨탠트35",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 36,
+    //유저 프로필 이미지
+    title: "테스트36",
+    content: "테스트 컨탠트36",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
   }
-  ///
 ];

--- a/client/src/mocks/infiniteScrollData.ts
+++ b/client/src/mocks/infiniteScrollData.ts
@@ -1,0 +1,58 @@
+
+import { CommuProps } from "@/types"
+
+export const commu: CommuProps[] = [
+  {
+    id: 1,
+    //유저 프로필 이미지
+    title: "박효정씨는 아침 요청입니다.",
+    content: "매일 아침마다 효정씨는 모두에게 아침 인사를 해줍니다. 아주 성실한 친구죠.",
+    view: 208,
+    division: "RECRUITMENT",
+    name: "phy",
+    created_at: "2023-06-21T17:34:51.3395597",
+    modifiedAt: "2023-06-21T17:34:51.3395597",
+    memberId: 1,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 2,
+    //유저 프로필 이미지
+    title: "위정연씨는 칭찬 스티커를 줍니다.",
+    content: "잘 하는 사람만 정연씨의 칭찬 스티커를 받을 수 있죠.",
+    view: 200,
+    division: "COOPERATION",
+    name: "yjy",
+    created_at: "2023-05-21T17:34:51.3395597",
+    modifiedAt: "2023-05-21T17:34:51.3395597",
+    memberId: 2,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 3,
+    //유저 프로필 이미지
+    title: "김다함씨는 열정맨입니다.",
+    content: "다함씨는 조용히 다함",
+    view: 150,
+    division: "COOPERATION",
+    name: "kdh",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 3,
+    status: "POST_ACTIVE"
+  },
+  {
+    id: 4,
+    //유저 프로필 이미지
+    title: "테스트4",
+    content: "테스트 컨탠트4",
+    view: 150,
+    division: "COOPERATION",
+    name: "testUser",
+    created_at: "2023-04-21T17:34:51.3395597",
+    modifiedAt: "2023-04-21T17:34:51.3395597",
+    memberId: 4,
+    status: "POST_ACTIVE"
+  }
+  ///
+];

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -19,7 +19,7 @@ import {
 
 export default function CommunityDetail( {handleClick}:any ) {
   const [ memberData, setMemberData ] = useState<CommuProps | null>(null); 
-  const { board_id:boardId } = useParams(); //_ 상수일 때만 사용 + 전체 대문자 -> 별칭 : boardId로 쓰겠다.
+  const { id:boardId } = useParams(); 
 
   useEffect(()=> {
     const findBoardsById = (id: string) => call(`/boards/${id}`, 'GET', null);
@@ -33,15 +33,14 @@ export default function CommunityDetail( {handleClick}:any ) {
 
     getMember();
   }, [boardId]);
-  // earlyreturn pattern : memberData가 없는 경우 37까지만 실행하고 끝 -> 성능 상승 
+
   if(!memberData) return <PageWrapper><Loading/></PageWrapper>
- // eslint prettier 적용하기 : 과제 (0712)
+
   return (
     <PageWrapper >
-      {/* !== 처럼 바로 이해안되는 거는 노노  -> 삼항연산자 삭제 */}
-      {/* member_id change */}
+
         <UserProfile type={'blackboard'} 
-          user={{ member_id: memberData.member_id, 
+          user={{ member_id: memberData.memberId, 
                   name: memberData.name, 
                   picture: 'https://picsum.photos/200/300' 
                 }} 

--- a/client/src/types/index.ts
+++ b/client/src/types/index.ts
@@ -30,7 +30,7 @@ export interface Styledprops
 
 //0707 혜진 community-main:<data> commu
 export interface CommuProps {
-  board_id: number,
+  id: number,
   title: string,
   content: string,
   view: number,
@@ -38,7 +38,7 @@ export interface CommuProps {
   name: string,
   created_at: string,
   modifiedAt: string,
-  member_id: number,
+  memberId: number,
   status:string,
   comments?: CommentProps[]
 }
@@ -47,7 +47,7 @@ export interface CommuProps {
 export interface CommentProps {
   comments_id: number;
   content: string;
-  member_id: number;
+  memberId: number;
   name: string;
   createdAt: string;
   modifiedAt: string;

--- a/client/src/utils/ApiService.tsx
+++ b/client/src/utils/ApiService.tsx
@@ -1,16 +1,17 @@
 /* 2023-07-07 axios 요청 함수 - 김다함 */
-import axios, { AxiosError, RawAxiosRequestConfig, AxiosResponse, AxiosHeaders } from 'axios'
+import axios, { RawAxiosRequestConfig, AxiosHeaders } from 'axios'
+// 23-07-12 네틀리파이 배포 준비 위해 임시 주석 처리 AxiosError, AxiosResponse - 혜진
 // import { CustomAxiosInterface } from '@/types/axiosInterface'
 // import { API_BASE_URL } from "@/app-config.js";
 const API_BASE_URL = ''
 const ACCESS_TOKEN = "ACCESS_TOKEN";
-const IS_ADMIN = "IS_ADMIN";
-const USER_NAME = "USER_NAME";
+// const IS_ADMIN = "IS_ADMIN";
+// const USER_NAME = "USER_NAME";
 
 axios.defaults.baseURL = API_BASE_URL;
 
-export async function call(api: string, method: string, data?: {}) {
-  let headers = new AxiosHeaders({
+export async function call(api: string, method: string, data?: any) {
+  const headers = new AxiosHeaders({
     "Content-Type": "application/json"
   });
 
@@ -19,7 +20,7 @@ export async function call(api: string, method: string, data?: {}) {
     headers.append("Authorization", "Bearer " + accessToken);
   }
 
-  let options: RawAxiosRequestConfig = {
+  const options: RawAxiosRequestConfig = {
     headers: headers,
     method: method,
     url: API_BASE_URL + api,


### PR DESCRIPTION
# 개요 
게시판 API 명세서 수정에 따른 변수 이름 변경 및 주석 정리 관련 PR 입니다. 

# 작업사항 
- CommunityDetail/ CommentBox, data, handler, App. 에서 사용되던 board_id 와 member_id를 각각 id와 memberId로 수정하였습니다. 
- 불필요한 주석 정리 
- 현재 무한 스크롤 테스트를 위해 _**게시판 전체 더미 데이터 : commu**_ 를 별도로 infiniteScrolldata로 빼서 게시판 목록 데이터들을 관리중입니다. 

# 스크린 샷
<img width="955" alt="스크린샷 2023-07-13 오후 3 02 07" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/88371570-9fd0-4b71-b331-8a15ecdeb821">


# 특이사항 
게시판 목록 중 테스트4 이름의 게시물들은 눌러도 상세 페이지로 이동 하지 않습니다. 