### PR TITLE
Fix: CategoryDropDown 컴포넌트에 isOpened 변수명 에러를 해결한다.

### DIFF
--- a/client/src/commons/molecules/CategoryDropDown.tsx
+++ b/client/src/commons/molecules/CategoryDropDown.tsx
@@ -3,7 +3,7 @@ import { useSelector } from 'react-redux/es/hooks/useSelector';
 import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
-import { category, isOpen } from '@/modules/categorySlice';
+import { category, isOpened } from '@/modules/categorySlice';
 
 import { FlexColumnWrapper } from '../styles/Containers.styled';
 import DropDownBox from '../atoms/dropdown/DropDownBox';
@@ -19,12 +19,12 @@ export const DropDownItemContainer = styled.div`
 
 export default function ContegroyDropDown() {
   const selectedCategory = useSelector(category);
-  const isOpened = useSelector(isOpen);
+  const isOpen = useSelector(isOpened);
 
   return (
     <FlexColumnWrapper gap={0}>
       <DropDownBox value={selectedCategory} />
-      {isOpened &&
+      {isOpen &&
         <DropDownItemContainer>
           <DropDownItem value='웹' />
           <DropDownItem value='앱' />


### PR DESCRIPTION
# 작업내용
* isOpen <-> isOpened 변수명이 일치하지 않아 발생한 에러를 수정하였습니다.