### PR TITLE
Fix: 고유 key 중복으로 인한 태그 체크 오류를 수정한다.

### DIFF
--- a/client/src/assets/data/categoryTags.ts
+++ b/client/src/assets/data/categoryTags.ts
@@ -28,19 +28,19 @@ export const categoryTags: CategoryTags = {
   "앱": {
     tags: [
       {
-        tagId: 1,
+        tagId: 6,
         name: 'android',
       },
       {
-        tagId: 2,
+        tagId: 7,
         name: 'iOS',
       },
       {
-        tagId: 3,
+        tagId: 8,
         name: 'react native',
       },
       {
-        tagId: 4,
+        tagId: 9,
         name: 'android studio',
       },
     ],
@@ -48,19 +48,19 @@ export const categoryTags: CategoryTags = {
   "3D/애니메이션": {
     tags: [
       {
-        tagId: 1,
+        tagId: 10,
         name: '음',
       },
       {
-        tagId: 2,
+        tagId: 11,
         name: '오',
       },
       {
-        tagId: 3,
+        tagId: 12,
         name: '아',
       },
       {
-        tagId: 4,
+        tagId: 13,
         name: '예',
       },
     ],
@@ -68,23 +68,23 @@ export const categoryTags: CategoryTags = {
   "디자인/일러스트": {
     tags: [
       {
-        tagId: 1,
+        tagId: 14,
         name: '훌라',
       },
       {
-        tagId: 2,
+        tagId: 15,
         name: '훌라',
       },
       {
-        tagId: 3,
+        tagId: 16,
         name: '신나고',
       },
       {
-        tagId: 4,
+        tagId: 17,
         name: '즐거운',
       },
       {
-        tagId: 5,
+        tagId: 18,
         name: '코딩시간',
       }
     ],
@@ -92,23 +92,23 @@ export const categoryTags: CategoryTags = {
   "사진/영상": {
     tags: [
       {
-        tagId: 1,
+        tagId: 19,
         name: '사실은',
       },
       {
-        tagId: 2,
+        tagId: 20,
         name: '하나도',
       },
       {
-        tagId: 3,
+        tagId: 21,
         name: '안 신나',
       },
       {
-        tagId: 4,
+        tagId: 22,
         name: '목이',
       },
       {
-        tagId: 5,
+        tagId: 23,
         name: '거북목된다',
       }
     ],

--- a/client/src/commons/atoms/dropdown/DropDownItem.tsx
+++ b/client/src/commons/atoms/dropdown/DropDownItem.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
 import { setCategory, openCategory, isOpened } from '@/modules/categorySlice';
+import { deleteTag } from '@/modules/tagSlice';
 
 interface DropDownItemProps {
   value: string;
@@ -25,6 +26,7 @@ export default function DropDownItem({ value }: DropDownItemProps) {
   const selectCategory = () => {
     dispatch(openCategory(!isOpen));
     dispatch(setCategory(value));
+    dispatch(deleteTag());
   }
 
   return (

--- a/client/src/commons/molecules/Tag.tsx
+++ b/client/src/commons/molecules/Tag.tsx
@@ -10,7 +10,7 @@ import { RxDotFilled } from 'react-icons/rx';
 const tagStyle = css`
     ${tw`w-fit py-1.5 px-2.5 rounded-full select-none flex`}
 `
-const TagBody = styled.div<{ isSelected?: boolean }>`
+const TagBody = styled.div<{ selected?: boolean, readonly?: boolean }>`
     ${tagStyle}
     background-color: #484848;
     border: 0.9px solid #C3C3C3;
@@ -20,7 +20,7 @@ const TagBody = styled.div<{ isSelected?: boolean }>`
         border-color: #dcdcdc;
     }
 
-    ${(props) => props.isSelected &&
+    ${(props) => props.selected && !props.readonly &&
     css`
       border-color: #dcdcdc;
       background-color: white;
@@ -36,18 +36,19 @@ const TagBody = styled.div<{ isSelected?: boolean }>`
 
 interface TagProps {
   tag: tag;
+  readonly?: boolean;
 }
 
-export const Tag = ({ tag }: TagProps) => {
+export const Tag = ({ tag, readonly }: TagProps) => {
   const [isSelected, onClick] = useTagSelect({
     isSelected: false,
-    tag: tag,
+    currentTag: tag,
   });
 
   return (
-    <TagBody isSelected={isSelected} onClick={onClick}>
+    <TagBody selected={isSelected} onClick={onClick} readonly={readonly}>
       <p className='text-xs'>{tag.name}</p>
-      {isSelected && <RxDotFilled className='dot' />}
+      {isSelected && !readonly && <RxDotFilled className='dot' />}
     </TagBody>
   )
 }

--- a/client/src/components/editor/TitleForm.tsx
+++ b/client/src/components/editor/TitleForm.tsx
@@ -6,10 +6,10 @@ import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 import tw from 'twin.macro';
 
+import { categoryTags } from '@/assets/data/categoryTags';
 import { Tag as tag } from '@/types';
 import { tags } from '@/modules/tagSlice';
 import { call } from '@/utils/apiService';
-import { categoryTags } from '@/assets/data/categoryTags';
 
 import { FlexColumnWrapper, FlexWrapper } from '@/commons/styles/Containers.styled';
 import { InputLabelText, SmallText } from '@/commons/atoms/Typography';

--- a/client/src/hooks/useTagSelect.tsx
+++ b/client/src/hooks/useTagSelect.tsx
@@ -6,16 +6,16 @@ import { selectTag } from '@/modules/tagSlice';
 import { Tag } from '@/types';
 
 interface TagProps {
-  tag: Tag;
+  currentTag: Tag;
   isSelected: boolean;
 }
 
-export default function useTagSelect({ tag, isSelected: selected }: TagProps) {
+export default function useTagSelect({ currentTag, isSelected: selected }: TagProps) {
   const [isSelected, setIsSelect] = useState<boolean>(selected);
   const dispatch = useDispatch();
 
   const onClick = useCallback(() => {
-    dispatch(selectTag(!isSelected, tag))
+    dispatch(selectTag(!isSelected, currentTag))
     setIsSelect(!isSelected);
   }, [isSelected])
 

--- a/client/src/modules/tagSlice.ts
+++ b/client/src/modules/tagSlice.ts
@@ -5,8 +5,10 @@ import { RootState } from '@/modules/index';
 import { Tag, TagSlice } from '@/types';
 
 export const SELECT_TAG = 'SELECT_TAG' as const;
+export const DELETE_TAG = 'DELETE_TAG' as const;
 
 export const selectTag = (isSelected: boolean, tag: Tag) => ({ type: SELECT_TAG, isSelected, tag });
+export const deleteTag = () => ({ type: DELETE_TAG })
 
 const initialState: TagSlice = {
   isSelected: false,
@@ -23,10 +25,12 @@ const { reducer: tagReducer } = createSlice({
       if (action.isSelected) state.selectedTags = [...state.selectedTags, action.tag]
       else state.selectedTags = state.selectedTags.filter((tag: Tag) => tag.name !== action.tag.name);
     },
+    DELETE_TAG: (state, action) => {
+      state.selectedTags = [];
+    }
   },
 });
 
-export const isSelect = (state: RootState) => state.tagSlice.isSelected;
 export const tags = (state: RootState) => state.tagSlice.selectedTags;
 
 export default tagReducer;

--- a/client/src/pages/portfolio-detail/PortfolioDetail.tsx
+++ b/client/src/pages/portfolio-detail/PortfolioDetail.tsx
@@ -78,7 +78,7 @@ export default function PortfolioDetail() {
             <LabelText color='white'>Tags</LabelText>
             <FlexWrapper gap={8}>
               {portfolio &&
-                portfolio.tags.map((tag: tag) => <Tag tag={tag} key={tag.tagId} />)
+                portfolio.tags.map((tag: tag) => <Tag tag={tag} key={tag.tagId} readonly={true} />)
               }
             </FlexWrapper>
           </UserCard>


### PR DESCRIPTION
# 작업내용
* `assets/data/categoryTags` 에 고유한 key 값이 될 id를 중복되게 만들어(1,2,3,4 반복) 발생한 태그 체크 오류를 수정하였습니다.
* 특정 카테고리에서 태그를 고른 후 태그 취소를 하지 않고 다른 카테고리로 변경했을 때, 지금까지 선택한 모든 태그를 초기화 시켰습니다.
* 포트폴리오 상세보기 페이지에서 태그 클릭 css 옵션을 막았습니다.