### PR TITLE
Feat: CommunityMain에서 게시판 별 구분 기능 구현

### DIFF
--- a/client/src/commons/atoms/header/CHeader.tsx
+++ b/client/src/commons/atoms/header/CHeader.tsx
@@ -20,7 +20,12 @@ export default function CHeader() {
         <Logo />
       </Link>
       <BtnContainer>
-        <RecuitBtn>Recruitment</RecuitBtn>&nbsp;&nbsp;|<CooperBtn>Cooperation</CooperBtn>
+        <Link to="/boards?division=RECRUITMENT">
+          <RecuitBtn>Recruitment</RecuitBtn>
+        </Link>&nbsp;&nbsp;|
+        <Link to="/boards?division=COOPERATION">
+          <CooperBtn>Cooperation</CooperBtn>
+        </Link>
         {loginState ? (
           <UserImg/>
         ) : (

--- a/client/src/commons/atoms/header/Header.tsx
+++ b/client/src/commons/atoms/header/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
       </Link>
       <Search />
       <ItemContainer>
-        <CLink href="/boards">
+        <CLink href="/boards?division=RECRUITMENT">
           <RecuitBtn>Community</RecuitBtn>
         </CLink>
         {loginState ? (

--- a/client/src/components/communityItem/CommunityItem.tsx
+++ b/client/src/components/communityItem/CommunityItem.tsx
@@ -10,12 +10,11 @@ import MemberProfile from '@/commons/molecules/MemberProfile';
 export default function CommunityItem({communityItem}: any) {
   const navigate = useNavigate();
   const eachData = communityItem;
-  console.log(eachData);
-  // console.log(eachData);
+  //console.log(eachData);
 
   const handleLink = (e: CommuProps) => {
     navigate(`/boards/${e.id}`, { state: e });
-    console.log(e.id);
+    //console.log(e.id);
   }
 
   return (

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -121,8 +121,19 @@ const UserRequestHandlers = [
 //혜진 게시판 파트 
 const HJHandlers = [
   //1. 게시판 목록 조회 GET : community-main page
-  rest.get('/boards', (_, res, ctx) => {
-    return res(ctx.status(200), ctx.json(commu));
+  //url-> http://localhost:8080/boards?division=COOPERATION
+  rest.get('/boards', (req, res, ctx) => {
+    const division = req.url.searchParams.get('division');
+
+    if( division === 'COOPERATION' ){
+      const filteredData = commu.filter((element) => element.division === 'COOPERATION');
+      return res(ctx.status(200), ctx.json(filteredData));
+    }
+
+    if( division === 'RECRUITMENT'){ 
+      const filteredData = commu.filter((element) => element.division === 'RECRUITMENT');
+      return res(ctx.status(200), ctx.json(filteredData));
+    }
   }),
   //2. 게시한 상세 페이지 조회 GET : community-detail page
   rest.get('/boards/:id', (req, res, ctx) => {

--- a/client/src/pages/community-main/CommunityMain.tsx
+++ b/client/src/pages/community-main/CommunityMain.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from 'react';
-import { Link } from 'react-router-dom';
+import { Link, useSearchParams } from 'react-router-dom';
 
 import Search from '@/components/search/Search';
 import { call } from '@/utils/apiService';
@@ -17,11 +17,13 @@ import {
 } from './CommunityMain.styled';
 
 export default function CommunityMain() {
-  const [data, setDatas] = useState<CommuProps[]>([])
+  const [ data, setDatas ] = useState<CommuProps[]>([])
+  const [ searchParams, setSearchParams ] = useSearchParams(); 
+  const division = searchParams.get('division')
 
   useEffect(() => {
     const axiosCommu = async () => {
-      return call('/boards', 'GET', null)
+      return call(`/boards?division=${division}`, 'GET', {params: {division: division}})
         .then((res) => {
           setDatas(res);
         })
@@ -29,7 +31,7 @@ export default function CommunityMain() {
     }
 
     axiosCommu();
-  }, []);
+  }, [division]);
 
 
   // 검색 - 07.11 효정


### PR DESCRIPTION
# 개요
커뮤니티 메인 페이지에서 헤더의 게시판 구분에 따른 목록 조회 기능 구현

# 작업 사항 
- 헤더의 게시판 클릭에 따른 목록 조회 기능 구현 
     * handler 부분 쿼리스트링에 따른 반환 값 수정

# 스크린 샷 
<img width="774" alt="스크린샷 2023-07-14 오후 2 12 46" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/cf674b23-6581-4aca-9437-cacab999a2c8">
<img width="843" alt="스크린샷 2023-07-14 오후 2 12 57" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/b80b0623-e9a7-4858-ab19-932c19d744a0">
