### PR TITLE
Feat: 카테고리 메인 페이지 dummydata 구현

### DIFF
--- a/client/src/components/appItem/AppItem.tsx
+++ b/client/src/components/appItem/AppItem.tsx
@@ -4,28 +4,28 @@ import {
   Title,
   TitleOverlay,
 } from './AppItem.stlyed';
-import item from '../../assets/appImg.png';
+import appImg from '../../assets/appImg.png';
 import { AiOutlineWifi } from 'react-icons/ai';
 import { BsBatteryFull } from 'react-icons/bs';
 import Bookmark from '../../commons/atoms/buttons/Bookmark';
 import { BookmarkWrapper } from '../webItem/WebItem.styled';
 
 type AppItemProps = {
-  itemCount: number;
+  item: any
 };
 
-export default function AppItem({ itemCount }: AppItemProps) {
-  const items = Array.from({ length: itemCount }, (_, index) => (
+export default function AppItem({ item }: AppItemProps) {
+  const items = Array.from({ length: 1 }, (_, index) => (
     <AppItemContainer>
       <span>10:30</span>
       <div className="iconsWrap">
         <AiOutlineWifi size={20} />
         <BsBatteryFull size={20} />
       </div>
-      <img src={item} alt={`appImg-${index}`} />
+      <img src={appImg} alt={`appImg-${index}`} />
       <TitleOverlay>
-        <Title>아이템 제목</Title>
-        <Author>작성자 이름</Author>
+        <Title>{item.data.title}</Title>
+        <Author>{item.data.membername}</Author>
       </TitleOverlay>
       <BookmarkWrapper>
         <Bookmark portfolioId={1} isToggled={false} />

--- a/client/src/components/graphicItem/GraphicItem.tsx
+++ b/client/src/components/graphicItem/GraphicItem.tsx
@@ -9,16 +9,16 @@ import Bookmark from '@/commons/atoms/buttons/Bookmark';
 import { BookmarkWrapper } from '../webItem/WebItem.styled';
 
 type GraphicProps = {
-  itemCount: number;
+  item: any;
 };
 
-export default function GraphicItem({ itemCount }: GraphicProps) {
-  const items = Array.from({ length: itemCount }, (_, index) => (
+export default function GraphicItem({ item }: GraphicProps) {
+  const items = Array.from({ length: 1 }, (_, index) => (
     <GraphicItemContainer>
       <img src={graphicimg} alt={`graphic image-${index}`} />
       <TitleOverlay>
-        <Title>3D 아이템 제목</Title>
-        <Author>작성자 이름</Author>
+        <Title>{item.data.title}</Title>
+        <Author>{item.data.membername}</Author>
       </TitleOverlay>
       <BookmarkWrapper>
         <Bookmark portfolioId={1} isToggled={false} />

--- a/client/src/components/photoItem/PhotoItem.tsx
+++ b/client/src/components/photoItem/PhotoItem.tsx
@@ -9,15 +9,17 @@ import {
 } from './PhotoItem.styled';
 
 type PhotoItem = {
-  itemCount: number;
+  item: any;
 };
 
-export default function PhotoItem({ itemCount }: PhotoItem) {
-  const items = Array.from({ length: itemCount }, (_, index) => (
+export default function PhotoItem({ item }: PhotoItem) {
+
+  console.log(item);
+  const items = Array.from({ length: 1 }, (_, index) => (
     <PhotoItemContainer>
       <img src={photoImg} alt={`photo image-${index}`} />
       <TitleOverlay>
-        <Title>3D 아이템 제목</Title>
+        <Title>{item.data.title}</Title>
         <Author>작성자 이름</Author>
       </TitleOverlay>
       <BookmarkWrapper>

--- a/client/src/components/threeDitem/ThreeDITem.tsx
+++ b/client/src/components/threeDitem/ThreeDITem.tsx
@@ -1,4 +1,4 @@
-import item from '../../assets/3DImg.png';
+import threeDimg from '../../assets/3DImg.png';
 import {
   Author,
   DItemContainer,
@@ -9,16 +9,16 @@ import { BookmarkWrapper } from '../webItem/WebItem.styled';
 import Bookmark from '@/commons/atoms/buttons/Bookmark';
 
 type AnimationProps = {
-  itemCount: number;
+  item: any;
 };
 
-export default function ThreeDItem({ itemCount }: AnimationProps) {
-  const items = Array.from({ length: itemCount }, (_, index) => (
+export default function ThreeDItem({ item }: AnimationProps) {
+  const items = Array.from({ length: 1 }, (_, index) => (
     <DItemContainer>
-      <img src={item} alt={`3Dimg-${index}`} />
+      <img src={threeDimg} alt={`3Dimg-${index}`} />
       <TitleOverlay>
-        <Title>3D 아이템 제목</Title>
-        <Author>작성자 이름</Author>
+        <Title>{item.data.title}</Title>
+        <Author>{item.data.membername}</Author>
       </TitleOverlay>
       <BookmarkWrapper>
         <Bookmark portfolioId={1} isToggled={false} />

--- a/client/src/components/webItem/WebItem.tsx
+++ b/client/src/components/webItem/WebItem.tsx
@@ -12,28 +12,20 @@ import {
 } from './WebItem.styled';
 
 type WebItemProps = {
-  itemCount: number; // 아이템 개수를 전달받는 prop
+  item: any;
 };
-// type WebItemProps = {
-//   portfolio: {
-//     title: string;
-//     member: {
-//       name: string;
-//       picture: string;
-//     };
-//   };
-// };
 
-export default function WebItem({ itemCount }: WebItemProps) {
+
+export default function WebItem({ item }: WebItemProps) {
   // export default function WebItem({ portfolio }: WebItemProps) {
   // const { title, member } = portfolio;
-  const items = Array.from({ length: itemCount }, (_, index) => (
-    <WebItemContainer>
+  const items = Array.from({ length: 1 }, (_, index) => (
+    <WebItemContainer key={index}>
       <Link to="/portfolios/:portfolioId">
         <WebItemImg src={WebItem1} alt={`웹 아이템 ${index + 1} 이미지`} />
       </Link>{' '}
       <TitleOverlay>
-        <Title>웹 테스트 제목</Title>
+        <Title>{item.data.title}</Title>
         <Author>작성자 이름</Author>
       </TitleOverlay>
       <BookmarkWrapper>

--- a/client/src/mocks/handlers.ts
+++ b/client/src/mocks/handlers.ts
@@ -2,7 +2,7 @@
 import { rest } from 'msw';
 
 import { portfolios, commuDetail, pictures } from './data';
-import { commu } from './infiniteScrollData'
+import { commu, WebCategoryDatas, AppCategoryDatas, AnimationCategoryDatas, GraphicCategoryDatas,PhotoCategoryDatas } from './infiniteScrollData'
 
 import { CommuProps } from '@/types';
 
@@ -255,7 +255,28 @@ const HJHandlers = [
   //로그아웃
   rest.get('/members/logout', async (_, res, ctx) => {
     return res(ctx.status(200), ctx.json('logout 성공'))
+  }),
+
+  //메인 카테고리별 조회 web
+  rest.get(`/portfolios`, async(req, res, ctx) => {
+    const category = req.url.searchParams.get('category');
+
+    if(category === 'web'){
+      return res(ctx.status(200), ctx.json(WebCategoryDatas))
+    } else if (category === 'app'){
+      return res(ctx.status(200), ctx.json(AppCategoryDatas))
+    } else if (category === '3danimation'){
+      return res(ctx.status(200), ctx.json(AnimationCategoryDatas))
+    } else if (category === 'graphicdesign') {
+      return res(ctx.status(200), ctx.json(GraphicCategoryDatas))
+    } else if (category === 'photo') {
+      return res(ctx.status(200), ctx.json(PhotoCategoryDatas))
+    }
+
+
   })
+
+
 
 ];
 

--- a/client/src/mocks/infiniteScrollData.ts
+++ b/client/src/mocks/infiniteScrollData.ts
@@ -472,24 +472,171 @@ export const commu: CommuProps[] = [
   },
 ];
 
+const getRandomNumber = (min:number, max:number) => {
+  return Math.floor(Math.random() * (max - min + 2));
+};
+
+export const WebCategoryDatas = [
+  //카테고리 별 입수  - WEB
+  {data: [
+    {
+      data:{
+        memberId: 1,
+        membername:"phj",
+        portfolioId: 1,
+        title: "제목1",
+        isMarked: false,
+
+      }
+    },
+    {
+      data:{
+        memberId: 2,
+        membername:"wjw",
+        portfolioId: 2,
+        title: "제목2",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId: 3,
+        membername:"kdh",
+        portfolioId: 3,
+        title: "제목3",
+        isMarked: false,
+      }
+    }
+
+  ]}
+
+]
+
+export const AppCategoryDatas = [
+  {data: [
+    {
+      data:{
+        memberId:1,
+        membername:"phj",
+        portfolioId:4,
+        title: "제목4",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:1,
+        membername:"phj",
+        portfolioId:5,
+        title: "제목5",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:1,
+        membername:"phj",
+        portfolioId:6,
+        title: "제목6",
+        isMarked: false,
+      }
+    },
+  ]}
+]
+
+export const AnimationCategoryDatas = [
+  {data: [
+    {
+      data:{
+        memberId:2,
+        membername:"wjw",
+        portfolioId:7,
+        title: "제목7",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:2,
+        membername:"wjw",
+        portfolioId:12,
+        title: "제목12",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:2,
+        membername:"wjw",
+        portfolioId:13,
+        title: "제목13",
+        isMarked: false,
+      }
+    },
+  ]}
+]
 
 
-// export const MainCategoryDatas = [
-//   data: [
-//     {
-//       data:{
-//         memberId: 1,
-//         portfolioId: 1,
-//         title: "제목1"
-//       }
-//     },
-//     {
-//       data:{
-//         memberId: 1,
-//         portfolioId: 1,
-//         title: "제목1"
-//       }
-//     }
-//   ]
+export const GraphicCategoryDatas = [
+  {data: [
+    {
+      data:{
+        memberId:3,
+        membername:"kdh",
+        portfolioId:8,
+        title: "제목8",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:3,
+        membername:"kdh",
+        portfolioId:9,
+        title: "제목9",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:3,
+        membername:"kdh",
+        portfolioId:10,
+        title: "제목10",
+        isMarked: false,
+      }
+    },
+  ]}
+]
 
-// ]
+export const PhotoCategoryDatas = [
+  {data: [
+    {
+      data:{
+        memberId:4,
+        membername:'jhj',
+        portfolioId:9,
+        title: "제목9",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:3,
+        membername:'jhj',
+        portfolioId:10,
+        title: "제목10",
+        isMarked: false,
+      }
+    },
+    {
+      data:{
+        memberId:3,
+        membername:'jhj',
+        portfolioId:11,
+        title: "제목11",
+        isMarked: false,
+      }
+    },
+  ]}
+]

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -1,3 +1,8 @@
+import { useEffect, useState } from 'react';
+import { useSelector } from 'react-redux';
+import { category } from '@/modules/categorySlice';
+import { call } from '@/utils/apiService';
+
 import CategoryNavBar from '@/components/navbar/CategoryNavBar';
 import WebItem from '@/components/webItem/WebItem';
 import { WebItemsContainer } from './Main.styled';
@@ -7,21 +12,58 @@ import '../../index.css';
 import AppItem from '@/components/appItem/AppItem';
 import GraphicItem from '@/components/graphicItem/GraphicItem';
 import PhotoItem from '@/components/photoItem/PhotoItem';
-import { useSelector } from 'react-redux';
-import { category } from '@/modules/categorySlice';
 import ThreeDItem from '@/components/threeDitem/ThreeDITem';
+
 
 export default function Main() {
   const selectedCategory = useSelector(category);
+  const [ items, setItems ] = useState([]);
+
+  useEffect(() => {
+    const getCategoryDatas = async () => {
+      
+      if(selectedCategory === '웹'){
+        return call(`portfolios?category=web`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+      }
+      if(selectedCategory === '앱'){
+        return  call(`portfolios?category=app`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+      }
+      if(selectedCategory === '3D/애니메이션'){
+        return  call(`portfolios?category=3danimation`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+      }
+      if(selectedCategory === '그래픽디자인'){
+        return  call(`portfolios?category=graphicdesign`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+      }
+      if(selectedCategory === '사진/영상'){
+        return  call(`portfolios?category=photo`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+      }
+
+      return await call(`portfolios?category=web`, 'GET', null)
+        .then((res) => setItems(res[0].data));
+    };
+
+    getCategoryDatas();
+  }, [selectedCategory])
+
+ 
+
   return (
     <>
       <CategoryNavBar />
       <WebItemsContainer>
-        {selectedCategory === '웹' && <WebItem itemCount={4} />}
-        {selectedCategory === '앱' && <AppItem itemCount={6} />}
-        {selectedCategory === '3D/애니메이션' && <ThreeDItem itemCount={6} />}
-        {selectedCategory === '그래픽디자인' && <GraphicItem itemCount={6} />}
-        {selectedCategory === '사진/영상' && <PhotoItem itemCount={4} />}
+        {items.map((element, index) => {
+          if(selectedCategory === '웹'){return <WebItem item={element} key={index}/>}
+          if(selectedCategory === '앱'){return <AppItem item={element} key={index}/>}
+          if(selectedCategory === '3D/애니메이션'){return <ThreeDItem item={element} key={index}/>}
+          if(selectedCategory === '그래픽디자인'){return <GraphicItem item={element} key={index}/>}
+          if(selectedCategory === '사진/영상'){return <PhotoItem item={element} key={index}/>}
+
+        })}
       </WebItemsContainer>
     </>
   );

--- a/client/src/utils/apiService.tsx
+++ b/client/src/utils/apiService.tsx
@@ -1,11 +1,11 @@
 /* 2023-07-07 axios 요청 함수 - 김다함 */
 import axios, { RawAxiosRequestConfig, AxiosHeaders } from 'axios'
-import { getCookie } from './cookie';
-
+// import { getCookie } from './cookie';
+//ec2-13-125-77-46.ap-northeast-2.compute.amazonaws.com:8080
 export const API_BASE_URL = ''
-const ACCESS_TOKEN = getCookie('accesstoken');
-const REFRESH_TOKEN = getCookie('refereshtoken');
-console.log(ACCESS_TOKEN, REFRESH_TOKEN);
+const ACCESS_TOKEN = '';
+// const REFRESH_TOKEN = getCookie('refereshtoken');
+// console.log(ACCESS_TOKEN, REFRESH_TOKEN);
 
 axios.defaults.baseURL = API_BASE_URL;
 
@@ -15,6 +15,10 @@ export async function call(api: string, method: string, data?: any) {
     "withCredentials": true,
   });
 
+  const accessToken = localStorage.getItem(ACCESS_TOKEN);
+  if (accessToken) {
+  headers.append("Authorization", "Bearer " + accessToken);
+  }
 
   const options: RawAxiosRequestConfig = {
     headers: headers,


### PR DESCRIPTION
# 개요 
메인 카테고리 페이지 관련 더미 데이터 제작 및 get 조회 기능 구현

# 작업 사항 
- 메인 카테고리 별 더미 데이터 제작 
- GET 이용하여 카테고리 별 데이터 조회 : hover 시 포트폴리오 title과 name 
     * 북마크 전부 false : 전역 관리 미 구현 
     * 포트폴리오 이미지 백엔드에 요청 필요 ( 현재 더미데이터에 없음)
- tailwind-styled-components 삭제 되어서 추가 설치 : package-json 추가 했으나.. 이 PR 에는 안 올라간다. 

# 스크린 샷 
<img width="984" alt="스크린샷 2023-07-18 오후 6 11 10" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/ab1a1870-8757-4866-a7bf-82feb02b2a67">


