### PR TITLE
Fix: 게시판 상세 페이지 조회 및 수정 후 저장 기능 수정

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ const App = () => {
           <Route element={<CHeaderLayout />}>
             <Route path="/boards" element={<CommunityMain />} />
             <Route path="/boards/:id" element={<CommunityDetail />} />
-            <Route path="/boards/edit" element={<AddCommunity />} />
+            <Route path="/boards/edit/:id" element={<AddCommunity />} />
           </Route>
           <Route
             path="/portfolios/:portfolio_id"

--- a/client/src/pages/community-add/AddCommunity.tsx
+++ b/client/src/pages/community-add/AddCommunity.tsx
@@ -79,7 +79,7 @@ export default function AddCommunity() {
   //url에서 boardId 받아옵니다. 
   // 최초 랜더링 시 해당 게시글을 reqct-quill에 뿌립니다. 
   useEffect(() => {
-    if(location.pathname === `/boards/${communityNum}`){
+    if(location.pathname === `/boards/edit/${communityNum}`){
       axios.get(`/api/boards/${communityNum}`)
       .then((res) => {
         setTitle(res.data.title);


### PR DESCRIPTION
# 개요 
게시판 상세 페이지 조회 및 수정 후 저장 기능 수정 

# 작업 사항 
- App.tsx 에서 addCommunity 페이지 경로 미스 설정
- AddComunity 파일에서 pathname을 통해서 url의 정보를 불러오지 못해서 생긴 오류 수정 


# 스크린 샷 
![업로드](https://github.com/codestates-seb/seb44_main_013/assets/110151638/e21e0148-4127-41b6-883f-3c3b90ce3c2e)

![스크린샷 2023-07-19 오후 1 48 32](https://github.com/codestates-seb/seb44_main_013/assets/110151638/f72f009c-4eca-4baa-a1e2-e18b72aeb741)
