### PR TITLE
Fix: 댓글 react #321 error 해결 위해 useState 삭제

### DIFF
--- a/client/src/components/comment/CommentBox.tsx
+++ b/client/src/components/comment/CommentBox.tsx
@@ -14,7 +14,7 @@ import { JbWrapper } from '@/pages/community-detail/CommunityDetail.styled';
 import noComment from '@/assets/noComment.png';
 import netaxios from '@/utils/axiosIntercept';
 
-export default function CommentBox({ comments = [], handleRender }: any) {
+export default function CommentBox({ comments = [] }: any) {
   const [currentComment, setCurrentComment] = useState('');
   const [amendComment, setAmendComment] = useState(comments);
   const [deleteId, setDeleteId] = useState(null);
@@ -37,12 +37,11 @@ export default function CommentBox({ comments = [], handleRender }: any) {
         .then((res) => {
           console.log('댓글 등록 완료');
           console.log(res);
-          handleRender();
         })
         .catch((err) => console.log(err));
     };
 
-    useEffect(() => {}, [saveComment]);
+    // useEffect(() => {}, [saveComment]);
     // const addNewComment = () =>
     //   call(`/comments`, 'POST', {
     //     id: boardId,

--- a/client/src/pages/community-detail/CommunityDetail.tsx
+++ b/client/src/pages/community-detail/CommunityDetail.tsx
@@ -15,15 +15,10 @@ import { CmDContainer, CommentContainer, MainContainer, PageWrapper } from './Co
 export default function CommunityDetail({ handleClick }: any) {
   const [memberData, setMemberData] = useState<CommuProps | null>(null);
   const [clickDeletePost, setClickDeletePost] = useState(false);
-  //야매로 트리거
-  const [render, setRender] = useState(true);
+
   const navigate = useNavigate();
   const { id: boardId } = useParams();
   // console.log(boardId);
-
-  const handleRender = () => {
-    setRender(!render);
-  };
 
   useEffect(() => {
     const findBoardsById = (id: string) => call(`/boards/${id}`, 'GET', null);
@@ -39,7 +34,7 @@ export default function CommunityDetail({ handleClick }: any) {
 
     getMember();
     console.log(memberData);
-  }, [boardId, render]);
+  }, [boardId]);
 
   if (!memberData)
     return (
@@ -85,7 +80,7 @@ export default function CommunityDetail({ handleClick }: any) {
           />
         </CmDContainer>
         <CommentContainer>
-          <CommentBox comments={memberData.comments} handleRender={handleRender} />
+          <CommentBox comments={memberData.comments} />
         </CommentContainer>
       </MainContainer>
       {clickDeletePost ? <DeleteModal onConfirm={handleDeleteModal} onCancel={handleDeleteModal} /> : ''}


### PR DESCRIPTION
# 개요 
댓글 commentBox 에서 상위 컴포넌트로부터 useState 받는 부분에 에러 #321 발생하여 삭제. 

# 확인 필요 사항 
useState 부분 삭제 시 댓글 등록 시 새로 고침을 해야 새롭게 글이 등록 되는 부분 해결 필요. 
- 현재 refresh token 문제로 일단 보류 