### PR TITLE
Feat: 메인 카테고리 랭킹 기능 추가 + 헤더(fixed) + 카테고리 focus 효과 추가

### DIFF
--- a/client/src/commons/atoms/buttons/category/CategoryButton.tsx
+++ b/client/src/commons/atoms/buttons/category/CategoryButton.tsx
@@ -49,11 +49,16 @@ export interface CategoryBtnProps {
 // style3;
 const Category = styled.button`
   ${tw`h-12 px-10 text-base font-semibold text-gray-400 uppercase tracking-wider border border-transparent rounded-md bg-transparent focus:outline-none transition-all duration-300 ease-in-out transform active:scale-95`}
-  &:hover, &:focus {
+  &:hover {
+    color: white;
+  }
+  &:focus {
+    border: 1px solid #d6ace2;
+    border-radius: 70px;
     color: white;
   }
 `;
 
 export default function CategoryButton({ category, onClick }: CategoryBtnProps) {
-  return <Category onClick={onClick}>{matchCategory(category)}</Category>
+  return <Category onClick={onClick}>{matchCategory(category)}</Category>;
 }

--- a/client/src/components/header/CHeader.styled.tsx
+++ b/client/src/components/header/CHeader.styled.tsx
@@ -14,6 +14,8 @@ export const HeaderContainer = tw.div`
   py-3
   bg-transparent
   z-50
+  sticky
+  top-0
 
 `;
 
@@ -33,8 +35,7 @@ export const RecuitBtn = styled.button<ButtonProps>`
     transition-colors
     text-gray-400
   `}
-  color: ${(props) =>
-    props.isActive ? ' #ffff' : props.color ? props.color : ' text-gray-400'};
+  color: ${(props) => (props.isActive ? ' #ffff' : props.color ? props.color : ' text-gray-400')};
 
   &:hover {
     color: #ffffff;
@@ -53,8 +54,7 @@ export const CooperBtn = styled.button<ButtonProps>`
     transition-colors
     text-gray-400
   `}
-  color: ${(props) =>
-    props.isActive ? ' #ffff' : props.color ? props.color : ' text-gray-400'};
+  color: ${(props) => (props.isActive ? ' #ffff' : props.color ? props.color : ' text-gray-400')};
 
   &:hover {
     color: #ffffff;

--- a/client/src/components/header/Header.styled.tsx
+++ b/client/src/components/header/Header.styled.tsx
@@ -7,6 +7,8 @@ export const HeaderContainer = tw.div`
   justify-between
   px-10
   py-3
+  sticky
+  top-0
 `;
 
 export const ItemContainer = tw.div`

--- a/client/src/components/navbar/CategoryNavBar.tsx
+++ b/client/src/components/navbar/CategoryNavBar.tsx
@@ -15,7 +15,7 @@ export default function CategoryNavBar() {
 
   return (
     <StyleSheetManager shouldForwardProp={(prop) => prop !== 'gap'}>
-      <FlexContainer gap={20} bg="transparent">
+      <FlexContainer gap={20} bg="transparent" className="sticky top-0 z-50">
         {Categories.map((category, index) => {
           return <CategoryButton onClick={() => dispatch(setCategory(category))} category={category} key={index} />;
         })}

--- a/client/src/components/ranking/Ranking.styled.tsx
+++ b/client/src/components/ranking/Ranking.styled.tsx
@@ -1,0 +1,67 @@
+import tw from 'twin.macro';
+import styled from 'styled-components';
+
+export const RankingContainer = tw.div`
+    my-3
+    mx-7
+    pb-3
+    flex
+    flex-row
+    overflow-x-scroll
+`;
+
+export const ItemImg = styled.img`
+  ${tw`
+    w-full
+    h-full
+    object-cover
+    transition
+    ease-in-out
+    relative
+    duration-300
+    `}
+
+  &:hover {
+    transform: scale(1.5);
+  }
+`;
+
+export const RankingItem = tw.div`
+    w-80
+    h-72
+    relative
+    shadow-md
+    mx-3
+    rounded-2xl
+    overflow-hidden
+`;
+
+export const TitleContainer = styled.div`
+  ${tw`
+    flex
+    flex-col
+    pb-5
+    text-BASIC_WHITE
+    font-bold
+    justify-end
+    absolute
+    w-full
+   bg-black
+   bg-opacity-75
+    bottom-0
+    z-20
+    `}
+`;
+
+export const TitlePart = tw.div`
+    text-3xl
+    font-bold
+    text-BASIC_WHITE
+    pl-3
+    mt-3
+`;
+
+export const ContentPart = tw.div`
+    text-xl
+    pl-3
+`;

--- a/client/src/components/ranking/Ranking.tsx
+++ b/client/src/components/ranking/Ranking.tsx
@@ -1,0 +1,28 @@
+import { Link } from 'react-router-dom';
+
+import { Portfolio } from '@/types';
+import { ContentPart, ItemImg, RankingContainer, RankingItem, TitleContainer, TitlePart } from './Ranking.styled';
+
+export default function Ranking(items: any) {
+  const rankingData = items.items.sort((a: Portfolio, b: Portfolio) => b.view - a.view);
+  console.log(rankingData);
+  return (
+    <RankingContainer>
+      {rankingData.length > 0
+        ? rankingData.map((item: Portfolio) => {
+            return (
+              <Link to={`/portfolios/${item.id}`}>
+                <RankingItem>
+                  <TitleContainer>
+                    <TitlePart>{item.title}</TitlePart>
+                    <ContentPart>@ {item.member.name}</ContentPart>
+                  </TitleContainer>
+                  <ItemImg src={item.firstImage} alt={item.title} />
+                </RankingItem>
+              </Link>
+            );
+          })
+        : null}
+    </RankingContainer>
+  );
+}

--- a/client/src/pages/main/Main.styled.tsx
+++ b/client/src/pages/main/Main.styled.tsx
@@ -25,3 +25,11 @@ export const NodataImage = styled.img`
   height: 350px;
   margin-top: 60px;
 `;
+
+export const BigTitle = tw.div`
+    text-2xl
+    font-semibold
+    text-BASIC_WHITE
+    ml-10
+    mt-10
+`;

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -5,7 +5,7 @@ import { category } from '@/store/categorySlice';
 
 import CategoryNavBar from '@/components/navbar/CategoryNavBar';
 import WebItem from '@/components/webItem/WebItem';
-import { WebItemsContainer, NodataImage } from './Main.styled';
+import { WebItemsContainer, NodataImage, BigTitle } from './Main.styled';
 import AppItem from '@/components/appItem/AppItem';
 import GraphicItem from '@/components/graphicItem/GraphicItem';
 import PhotoItem from '@/components/photoItem/PhotoItem';
@@ -13,6 +13,7 @@ import ThreeDItem from '@/components/threeDitem/ThreeDITem';
 import Search from '@/components/search/Search';
 import datano from '@/assets/datano.png';
 import axios from 'axios';
+import Ranking from '@/components/ranking/Ranking';
 
 const categoryMap = {
   web: 'web',
@@ -92,6 +93,8 @@ export default function Main() {
     <>
       <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
       <CategoryNavBar />
+      <BigTitle>{`현재 인기 작품 순위`}</BigTitle>
+      <Ranking items={searchs} key={searchs.id} />
       <WebItemsContainer>
         {searchs.length > 0 ? (
           searchs.map((searchedItem: any, index: any) => {


### PR DESCRIPTION
# 개요 
메인 카테고리 랭킹 기능 추가 ( 조회수 기준 ) + 헤더 (fixed) + 카테고리 focus 효과 추가 관련 PR 입니다.

# 작업 사항
1. 메인 카테고리에서 카테고리 별로 조회수 기준 오늘의 랭킹 기능을 추가하였습니다. 
2. 헤더와 카테고리의 위치를 top-0 으로 fixed 하여 스크롤을 내려도 기능을 사용할 수 있습니다. 
3. 카테고리 focus border 효과 추가하여 직관적으로 UI 수정하였습니다. 

# 작업 사진 
<img width="1104" alt="스크린샷 2023-08-19 오후 11 47 41" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/4290f84f-2c5a-4a79-b552-984d536970fc">

# 참고 디자인 
<img width="1124" alt="스크린샷 2023-08-19 오후 11 49 17" src="https://github.com/codestates-seb/seb44_main_013/assets/110151638/3d5b4fc9-8d35-4bbe-a4c8-474b9853ca3a">


# 추가 작업 예정 사항 
1. 몇 사진이 깨지는 현상이 발생했습니다. 
2. mouse move event 도 적용할 예정입니다. 더불어 현재는 그저 overflow-scroll 이지만 클릭으로 넘어갈 수 있게도 할 예정입니다. 
3. 현재는 한번 페이지 랜딩시 마다 조회되는 데이터의 조회수 기준이지만 특정 시간 기준 자동 업데이트 되도록 수정할 예정입니다. 
4. 헤더와 카테고리의 배경이 투명하여 스크롤 다운 시 메인 아이템들과 겹쳐 육안으로 잘 확인 되지 않는 현상이 있습니다. 