### PR TITLE
Feat: 메인페이지 랭킹 6시간 마다 업데이트 설정

### DIFF
--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -78,29 +78,44 @@ export default function Main() {
   };
 
   const [searchs, setSearchs] = useState([] as any);
+  const [ timeUpdate, setTime ] = useState(`...시`);
 
   useEffect(() => {
+    console.log('페이지 업데이트')
     if (searchTerm === '') {
       setSearchs(renderItems());
     }
 
     setSearchs(items);
-  }, [items]);
+  }, [items, timeUpdate]);
 
   console.log(searchs);
 
-  const currentTime = new Date(new Date().getTime());
-  const hour = currentTime.getHours();
-  const divisionPeriod = hour > 12 ? '오후' : '오전';
-  const changedHour = hour > 12 ? hour - 12 : hour;
-  const updatedTimeSet = `${divisionPeriod} ${changedHour}시`;
-  console.log(updatedTimeSet);
+  const handleTime = () => {
+    const currentTime = new Date(new Date().getTime());
+    const hour = currentTime.getHours();
+    const divisionPeriod = hour > 12 ? '오후' : '오전';
+    const changedHour = hour > 12 ? hour - 12 : hour;
+    const updatedTimeSet = `${divisionPeriod} ${changedHour}시`;
+    setTime(updatedTimeSet)
+
+    console.log('업데이트 : ', updatedTimeSet);
+  }
+
+  const intervalTime = () => {
+    //6시간 마다 업데이트 
+    setInterval(handleTime, 21600000);
+    console.log('intervalTime 함수가 실행됩니다.')
+  }
+
+  intervalTime();
+  
 
   return (
     <>
       <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
       <CategoryNavBar />
-      <BigTitle>{`현재 인기 작품 순위 [ ${updatedTimeSet} 기준]`}</BigTitle>
+      <BigTitle>{`현재 인기 작품 순위 [ ${timeUpdate} 기준]`}</BigTitle>
       <Ranking items={searchs} key={searchs.id} />
       <WebItemsContainer>
         {searchs.length > 0 ? (


### PR DESCRIPTION
# 개요
메인 페이지의 랭킹 업데이트를 6시간 마다 업데이트 되도록 설정한 PR 입니다. 

# 작업 사항 
- setInterval 메서드를 사용하여 6시간 마다 랭킹 자료가 업데이트 되도록 설정하였습니다. 
- useEffect 함수에 6시간 업데이트 시 변경되는 시간의 값에 따라 페이지가 리랜더링되어 메인 랭킹 자료도 새롭게 업데이트 될 수 있도록 하였습니다. 
![스크린샷 2023-08-29 오후 11 41 34](https://github.com/codestates-seb/seb44_main_013/assets/110151638/3f869b3f-505f-4694-aaa0-575b3a3198e6)
