### PR TITLE
Fix: useToggle에서 useCallback을 제거한다.

### DIFF
--- a/client/src/hooks/useToggle.tsx
+++ b/client/src/hooks/useToggle.tsx
@@ -19,7 +19,7 @@ export default function useToggle({ portfolioId, buttonType, isToggled: isOn, co
 
   const changeToggleClicks = () => call(url, 'GET');
 
-  const onClick = useCallback(async () => {
+  const onClick = async () => {
     if (isToggled)
       await changeToggleClicks();
       setButtonColor('gray');
@@ -31,7 +31,7 @@ export default function useToggle({ portfolioId, buttonType, isToggled: isOn, co
       buttonType === 'likes' && setCount(count + 1);
 
     setIsToggled(!isToggled);
-  }, [isToggled, count])
+  }
 
   return [buttonColor, onClick, count] as const;
 }


### PR DESCRIPTION
## 작업내용
* useToggle 훅의 onClick 함수에 useCallback이 불필요하다고 판단하여 제거했습니다.