### PR TITLE
Fix: 랭킹 기능 최초값 설정 및 시간 업데이트에 따른 시간 업데이트 미 적용 부분 수정 

### DIFF
--- a/client/src/components/ranking/Ranking.tsx
+++ b/client/src/components/ranking/Ranking.tsx
@@ -3,32 +3,29 @@ import { Link } from 'react-router-dom';
 import { Portfolio } from '@/types';
 import { ContentPart, ItemImg, RankingContainer, RankingItem, TitleContainer, TitlePart, BigTitle, RankingItemContainer } from './Ranking.styled';
 import noPic from '@/assets/noPic.png';
-import { Dispatch, SetStateAction } from 'react';
+import { useEffect } from 'react';
 
 interface RankingItemsTypes {
   items: Portfolio[];
-  setTime: Dispatch<SetStateAction<string>>;
   timeUpdate: string;
+  handleTime: () => void;
 }
  
-export default function Ranking({items, setTime, timeUpdate}: RankingItemsTypes) {
-  console.log(items);
+export default function Ranking({items, timeUpdate, handleTime}: RankingItemsTypes) {
+  //console.log(items);
   const rankingData = items.sort((a: Portfolio, b: Portfolio) => b.view - a.view);
 
-  const handleTime = () => {
-    setInterval(() => {
-      const currentTime = new Date(new Date().getTime());
-      const hour = currentTime.getHours();
-      const divisionPeriod = hour > 12 ? '오후' : '오전';
-      const changedHour = hour > 12 ? hour - 12 : hour;
-      const updatedTimeSet = `${divisionPeriod} ${changedHour}시`;
-      setTime(updatedTimeSet)
+  useEffect(() => {
+    const handleInterval = setInterval(() => {
+      handleTime();
+      console.log('인터벌 함수 실행합니다.', timeUpdate);
     }, 21600000);
-//21600000
-    console.log('인터벌 함수 실행합니다.', timeUpdate);
-  }
 
-  handleTime();
+    return () => {
+      clearInterval(handleInterval);
+    }
+  }, [timeUpdate]);
+
 
   return (
     <RankingContainer>

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -4,7 +4,7 @@ import { category } from '@/store/categorySlice';
 
 import CategoryNavBar from '@/components/navbar/CategoryNavBar';
 import WebItem from '@/components/webItem/WebItem';
-import { WebItemsContainer, NodataImage, BigTitle } from './Main.styled';
+import { WebItemsContainer, NodataImage } from './Main.styled';
 import AppItem from '@/components/appItem/AppItem';
 import GraphicItem from '@/components/graphicItem/GraphicItem';
 import PhotoItem from '@/components/photoItem/PhotoItem';

--- a/client/src/pages/main/Main.tsx
+++ b/client/src/pages/main/Main.tsx
@@ -4,7 +4,7 @@ import { category } from '@/store/categorySlice';
 
 import CategoryNavBar from '@/components/navbar/CategoryNavBar';
 import WebItem from '@/components/webItem/WebItem';
-import { WebItemsContainer, NodataImage } from './Main.styled';
+import { WebItemsContainer, NodataImage, BigTitle } from './Main.styled';
 import AppItem from '@/components/appItem/AppItem';
 import GraphicItem from '@/components/graphicItem/GraphicItem';
 import PhotoItem from '@/components/photoItem/PhotoItem';
@@ -72,7 +72,26 @@ export default function Main() {
   };
 
   const [searchs, setSearchs] = useState([] as any);
-  const [ timeUpdate, setTime ] = useState(`...시`);
+  const [ timeUpdate, setTime ] = useState(() => {
+    const currentTime = new Date(new Date().getTime());
+    const hour = currentTime.getHours();
+    //const minute = currentTime.getMinutes();
+    const divisionPeriod = hour > 12 ? '오후' : '오전';
+    const changedHour = hour > 12 ? hour - 12 : hour;
+    const updatedTimeSet = `${divisionPeriod} ${changedHour}시`;
+    return updatedTimeSet;
+  });
+
+  const handleTime = () => {
+    const currentTime = new Date(new Date().getTime());
+    const hour = currentTime.getHours();
+    //const minute = currentTime.getMinutes();
+    const divisionPeriod = hour > 12 ? '오후' : '오전';
+    const changedHour = hour > 12 ? hour - 12 : hour;
+    const updatedTimeSet = `${divisionPeriod} ${changedHour}시`;
+    setTime(updatedTimeSet);
+  };
+
 
   useEffect(() => {
     console.log('페이지 업데이트')
@@ -81,7 +100,7 @@ export default function Main() {
     }
 
     setSearchs(items);
-  }, [items, timeUpdate]);
+  }, [items]);
 
   //console.log(searchs);
 
@@ -89,7 +108,7 @@ export default function Main() {
     <>
       <Search setSearchValue={setSearchTerm} currentSearch={searchTerm} data={items} setSearchs={setSearchs} />
       <CategoryNavBar />
-      <Ranking items={searchs} key={searchs.id} setTime={setTime} timeUpdate={timeUpdate}/>
+      <Ranking items={searchs} key={searchs.id} timeUpdate={timeUpdate} handleTime={handleTime}/>
       <WebItemsContainer>
         {searchs.length > 0 ? (
           searchs.map((searchedItem: any, index: any) => {


### PR DESCRIPTION
# 개요 
메인 페이지 랭킹 기능 최초값 설정 및 설정한 6시간 업데이트 될 때 랭킹 시간 업데이트 안되었던 에러 수정한 PR 입니다. 

# 작업 사항 
Main컴포넌트로 `handleTime()`을 빼고 Ranking 컴포넌트에서 별도로 useEffect를 적용하였습니다. 
 :  Main의 ScrollTo(0,0)요소와 겹치는 이중 상태 변경에 따른 경고 원인을 제거하였습니다. 
Main의 timeUpdate 요소의 최초값을 handleTime() 내부 함수로 적용하여 기존의 "..." 로 표시되던 최초값이 시간으로 표시될 수 있게 하였습니다. 
![스크린샷 2023-09-21 오후 9 55 59](https://github.com/codestates-seb/seb44_main_013/assets/110151638/2315875e-4ff9-4b40-b3e7-ffd8e9223eee)

